### PR TITLE
Add climate control device

### DIFF
--- a/bundles/org.openhab.binding.boschshc/.classpath
+++ b/bundles/org.openhab.binding.boschshc/.classpath
@@ -28,18 +28,21 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+	<classpathentry kind="src" path="target/generated-sources/annotations">
 		<attributes>
 			<attribute name="optional" value="true"/>
-			<attribute name="test" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 			<attribute name="ignore_optional_problems" value="true"/>
 			<attribute name="m2e-apt" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="target/generated-sources/annotations">
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
 		<attributes>
 			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/bundles/org.openhab.binding.boschshc/README.md
+++ b/bundles/org.openhab.binding.boschshc/README.md
@@ -11,6 +11,7 @@ Binding for the Bosch Smart Home Controller:
  - Bosch Motion Detector
  - Bosch Shutter Control in-wall
  - Bosch Thermostat
+ - Bosch Climate Control
 
 ## Limitations
 

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCBindingConstants.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCBindingConstants.java
@@ -35,6 +35,7 @@ public class BoschSHCBindingConstants {
     public static final ThingTypeUID THING_TYPE_MOTION_DETECTOR = new ThingTypeUID(BINDING_ID, "motion-detector");
     public static final ThingTypeUID THING_TYPE_SHUTTER_CONTROL = new ThingTypeUID(BINDING_ID, "shutter-control");
     public static final ThingTypeUID THING_TYPE_THERMOSTAT = new ThingTypeUID(BINDING_ID, "thermostat");
+    public static final ThingTypeUID THING_TYPE_CLIMATE_CONTROL = new ThingTypeUID(BINDING_ID, "climate-control");
 
     // List of all Channel IDs
     // Auto-generated from thing-types.xml via script, don't modify
@@ -53,4 +54,5 @@ public class BoschSHCBindingConstants {
     public static final String CHANNEL_LATEST_MOTION = "latest-motion";
     public static final String CHANNEL_LEVEL = "level";
     public static final String CHANNEL_VALVE_TAPPET_POSITION = "valve-tappet-position";
+    public static final String CHANNEL_SETPOINT_TEMPERATURE = "setpoint-temperature";
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCHandler.java
@@ -87,8 +87,8 @@ public abstract class BoschSHCHandler extends BaseThingHandler {
     }
 
     /**
-     * Initializes this handler. Use this method to register all services of the
-     * device with {@link #registerService(BoschSHCService)}.
+     * Initializes this handler. Use this method to register all services of the device with
+     * {@link #registerService(BoschSHCService)}.
      */
     @Override
     public void initialize() {
@@ -100,6 +100,13 @@ public abstract class BoschSHCHandler extends BaseThingHandler {
         updateStatus(ThingStatus.ONLINE);
     }
 
+    /**
+     * Handles the refresh command of all registered services. Override it to handle custom commands (e.g. to update
+     * states of services).
+     * 
+     * @param channelUID {@link ChannelUID} of the channel to which the command was sent
+     * @param command {@link Command}
+     */
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         if (command instanceof RefreshType) {
@@ -116,7 +123,7 @@ public abstract class BoschSHCHandler extends BaseThingHandler {
      * Processes an update which is received from the bridge.
      * 
      * @param serviceName Name of service the update came from.
-     * @param stateData   Current state of device service. Serialized as JSON.
+     * @param stateData Current state of device service. Serialized as JSON.
      */
     public void processUpdate(String serviceName, JsonElement stateData) {
         // Check services of device to correctly
@@ -128,6 +135,11 @@ public abstract class BoschSHCHandler extends BaseThingHandler {
         }
     }
 
+    /**
+     * Returns the bridge handler for this thing handler.
+     * 
+     * @return Bridge handler for this thing handler. Null if no or an invalid bridge was set in the configuration.
+     */
     protected @Nullable BoschSHCBridgeHandler getBridgeHandler() {
         Bridge bridge = this.getBridge();
         if (bridge == null) {
@@ -139,13 +151,13 @@ public abstract class BoschSHCHandler extends BaseThingHandler {
     /**
      * Creates and registers a new service for this device.
      * 
-     * @param <TService>          Type of service.
-     * @param <TState>            Type of service state.
-     * @param serviceClass        Class of service to instantiate a new instance.
+     * @param <TService> Type of service.
+     * @param <TState> Type of service state.
+     * @param serviceClass Class of service to instantiate a new instance.
      * @param stateUpdateListener Function to call when a state update was received
-     *                            from the device.
-     * @param affectedChannels    Channels which are affected by the state of this
-     *                            service.
+     *            from the device.
+     * @param affectedChannels Channels which are affected by the state of this
+     *            service.
      * @return Instance of registered service.
      */
     protected <TService extends BoschSHCService<TState>, TState extends BoschSHCServiceState> TService createService(
@@ -172,9 +184,9 @@ public abstract class BoschSHCHandler extends BaseThingHandler {
     /**
      * Registers a service of this device.
      * 
-     * @param service          Service which belongs to this device
+     * @param service Service which belongs to this device
      * @param affectedChannels Channels which are affected by the state of this
-     *                         service
+     *            service
      */
     protected <TState extends BoschSHCServiceState> void registerService(BoschSHCService<TState> service,
             Collection<String> affectedChannels) {

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCHandler.java
@@ -188,7 +188,7 @@ public abstract class BoschSHCHandler extends BaseThingHandler {
      * @param affectedChannels Channels which are affected by the state of this
      *            service
      */
-    protected <TState extends BoschSHCServiceState> void registerService(BoschSHCService<TState> service,
+    private <TState extends BoschSHCServiceState> void registerService(BoschSHCService<TState> service,
             Collection<String> affectedChannels) {
         this.services.add(new DeviceService<TState>(service, affectedChannels));
     }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCHandler.java
@@ -33,7 +33,14 @@ import org.openhab.binding.boschshc.internal.services.BoschSHCServiceState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@NonNullByDefault
 class DeviceService<TState extends BoschSHCServiceState> {
+
+    DeviceService(BoschSHCService<TState> service, Collection<String> affectedChannels) {
+        this.service = service;
+        this.affectedChannels = affectedChannels;
+    }
+
     /**
      * Service which belongs to the device.
      */
@@ -171,9 +178,6 @@ public abstract class BoschSHCHandler extends BaseThingHandler {
      */
     protected <TState extends BoschSHCServiceState> void registerService(BoschSHCService<TState> service,
             Collection<String> affectedChannels) {
-        DeviceService<TState> deviceService = new DeviceService<TState>();
-        deviceService.service = service;
-        deviceService.affectedChannels = affectedChannels;
-        this.services.add(deviceService);
+        this.services.add(new DeviceService<TState>(service, affectedChannels));
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCHandler.java
@@ -139,13 +139,18 @@ public abstract class BoschSHCHandler extends BaseThingHandler {
      * Returns the bridge handler for this thing handler.
      * 
      * @return Bridge handler for this thing handler. Null if no or an invalid bridge was set in the configuration.
+     * @throws Error If bridge for handler is not set or an invalid bridge is set.
      */
-    protected @Nullable BoschSHCBridgeHandler getBridgeHandler() {
+    protected BoschSHCBridgeHandler getBridgeHandler() {
         Bridge bridge = this.getBridge();
         if (bridge == null) {
-            return null;
+            throw new Error(String.format("No valid bridge set for {}", this.getThing()));
         }
-        return (BoschSHCBridgeHandler) bridge.getHandler();
+        BoschSHCBridgeHandler bridgeHandler = (BoschSHCBridgeHandler) bridge.getHandler();
+        if (bridgeHandler == null) {
+            throw new Error(String.format("Bridge of {} has no valid bridge handler", this.getThing()));
+        }
+        return bridgeHandler;
     }
 
     /**
@@ -164,7 +169,7 @@ public abstract class BoschSHCHandler extends BaseThingHandler {
             Class<TService> serviceClass, Consumer<TState> stateUpdateListener, Collection<String> affectedChannels) {
         BoschSHCBridgeHandler bridgeHandler = this.getBridgeHandler();
         if (bridgeHandler == null) {
-            throw new Error(String.format("Could not initialize service for {}, no valid bridge set", this.getThing()));
+            throw new Error(String.format("Could not create service for {}, no valid bridge set", this.getThing()));
         }
 
         String deviceId = this.getBoschID();

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCHandlerFactory.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCHandlerFactory.java
@@ -25,6 +25,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.openhab.binding.boschshc.internal.devices.climatecontrol.ClimateControlHandler;
 import org.openhab.binding.boschshc.internal.shuttercontrol.ShutterControlHandler;
 import org.openhab.binding.boschshc.internal.thermostat.ThermostatHandler;
 import org.osgi.service.component.annotations.Component;
@@ -49,7 +50,7 @@ public class BoschSHCHandlerFactory extends BaseThingHandlerFactory {
     // List of all supported Bosch devices.
     public static final Collection<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Arrays.asList(THING_TYPE_SHC,
             THING_TYPE_INWALL_SWITCH, THING_TYPE_TWINGUARD, THING_TYPE_WINDOW_CONTACT, THING_TYPE_MOTION_DETECTOR,
-            THING_TYPE_SHUTTER_CONTROL, THING_TYPE_THERMOSTAT);
+            THING_TYPE_SHUTTER_CONTROL, THING_TYPE_THERMOSTAT, THING_TYPE_CLIMATE_CONTROL);
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -90,6 +91,10 @@ public class BoschSHCHandlerFactory extends BaseThingHandlerFactory {
 
         else if (THING_TYPE_THERMOSTAT.equals(thingTypeUID)) {
             return new ThermostatHandler(thing);
+        }
+
+        else if (THING_TYPE_CLIMATE_CONTROL.equals(thingTypeUID)) {
+            return new ClimateControlHandler(thing);
         }
 
         else {

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/climatecontrol/ClimateControlHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/climatecontrol/ClimateControlHandler.java
@@ -22,7 +22,7 @@ import tec.uom.se.unit.Units;
  * A virtual device which controls up to six Bosch Smart Home radiator thermostats in a room.
  */
 @NonNullByDefault
-public class ClimateControlHandler extends BoschSHCHandler {
+public final class ClimateControlHandler extends BoschSHCHandler {
 
     @NonNullByDefault({})
     private RoomClimateControlService roomClimateControlService;
@@ -57,23 +57,33 @@ public class ClimateControlHandler extends BoschSHCHandler {
         }
     }
 
+    /**
+     * Updates the channels which are linked to the {@link TemperatureLevelService} of the device.
+     * 
+     * @param state Current state of {@link TemperatureLevelService}.
+     */
     private void updateChannels(TemperatureLevelServiceState state) {
         super.updateState(CHANNEL_TEMPERATURE, state.getTemperatureState());
     }
 
+    /**
+     * Updates the channels which are linked to the {@link RoomClimateControlService} of the device.
+     * 
+     * @param state Current state of {@link RoomClimateControlService}.
+     */
     private void updateChannels(RoomClimateControlServiceState state) {
         super.updateState(CHANNEL_SETPOINT_TEMPERATURE, state.getSetpointTemperatureState());
     }
 
+    /**
+     * Sets the desired temperature for the device.
+     * 
+     * @param quantityType Command which contains the new desired temperature.
+     */
     private void updateSetpointTemperature(QuantityType<?> quantityType) {
         QuantityType<?> celsiusType = quantityType.toUnit(Units.CELSIUS);
         if (celsiusType == null) {
             logger.debug("Could not convert quantity command to celsius");
-            return;
-        }
-
-        if (this.roomClimateControlService != null) {
-            logger.debug("RoomClimateControlService not initialized");
             return;
         }
 

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/climatecontrol/ClimateControlHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/climatecontrol/ClimateControlHandler.java
@@ -5,6 +5,7 @@ import static org.openhab.binding.boschshc.internal.BoschSHCBindingConstants.CHA
 
 import java.util.Arrays;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -17,8 +18,10 @@ import org.openhab.binding.boschshc.internal.services.temperaturelevel.Temperatu
 
 import tec.uom.se.unit.Units;
 
+@NonNullByDefault
 public class ClimateControlHandler extends BoschSHCHandler {
 
+    @NonNullByDefault({})
     private RoomClimateControlService roomClimateControlService;
 
     public ClimateControlHandler(Thing thing) {
@@ -40,10 +43,7 @@ public class ClimateControlHandler extends BoschSHCHandler {
         switch (channelUID.getId()) {
             case CHANNEL_SETPOINT_TEMPERATURE:
                 if (command instanceof QuantityType<?>) {
-                    // Set specific temperature
-                    QuantityType<?> quantityType = (QuantityType<?>) command;
-                    double setpointTemperature = quantityType.toUnit(Units.CELSIUS).doubleValue();
-                    this.roomClimateControlService.setState(new RoomClimateControlServiceState(setpointTemperature));
+                    updateSetpointTemperature((QuantityType<?>) command);
                 }
                 break;
         }
@@ -55,5 +55,21 @@ public class ClimateControlHandler extends BoschSHCHandler {
 
     protected void updateChannels(RoomClimateControlServiceState state) {
         super.updateState(CHANNEL_SETPOINT_TEMPERATURE, state.getSetpointTemperatureState());
+    }
+
+    private void updateSetpointTemperature(QuantityType<?> quantityType) {
+        QuantityType<?> celsiusType = quantityType.toUnit(Units.CELSIUS);
+        if (celsiusType == null) {
+            logger.debug("Could not convert quantity command to celsius");
+            return;
+        }
+
+        if (this.roomClimateControlService != null) {
+            logger.debug("RoomClimateControlService not initialized");
+            return;
+        }
+
+        double setpointTemperature = celsiusType.doubleValue();
+        this.roomClimateControlService.setState(new RoomClimateControlServiceState(setpointTemperature));
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/climatecontrol/ClimateControlHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/climatecontrol/ClimateControlHandler.java
@@ -20,6 +20,8 @@ import tec.uom.se.unit.Units;
 
 /**
  * A virtual device which controls up to six Bosch Smart Home radiator thermostats in a room.
+ * 
+ * @author Christian Oeing (christian.oeing@slashgames.org)
  */
 @NonNullByDefault
 public final class ClimateControlHandler extends BoschSHCHandler {

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/climatecontrol/ClimateControlHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/climatecontrol/ClimateControlHandler.java
@@ -1,0 +1,37 @@
+package org.openhab.binding.boschshc.internal.devices.climatecontrol;
+
+import static org.openhab.binding.boschshc.internal.BoschSHCBindingConstants.CHANNEL_SETPOINT_TEMPERATURE;
+import static org.openhab.binding.boschshc.internal.BoschSHCBindingConstants.CHANNEL_TEMPERATURE;
+
+import java.util.Arrays;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.openhab.binding.boschshc.internal.BoschSHCHandler;
+import org.openhab.binding.boschshc.internal.services.roomclimatecontrol.RoomClimateControlService;
+import org.openhab.binding.boschshc.internal.services.roomclimatecontrol.RoomClimateControlServiceState;
+import org.openhab.binding.boschshc.internal.services.temperaturelevel.TemperatureLevelService;
+import org.openhab.binding.boschshc.internal.services.temperaturelevel.TemperatureLevelServiceState;
+
+public class ClimateControlHandler extends BoschSHCHandler {
+    public ClimateControlHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+
+        super.createService(TemperatureLevelService.class, this::updateChannels, Arrays.asList(CHANNEL_TEMPERATURE));
+        super.createService(RoomClimateControlService.class, this::updateChannels,
+                Arrays.asList(CHANNEL_SETPOINT_TEMPERATURE));
+    }
+
+    protected void updateChannels(TemperatureLevelServiceState state) {
+        super.updateState(CHANNEL_TEMPERATURE, new DecimalType(state.temperature));
+    }
+
+    protected void updateChannels(RoomClimateControlServiceState state) {
+        super.updateState(CHANNEL_SETPOINT_TEMPERATURE, new DecimalType(state.setpointTemperature));
+    }
+}

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/climatecontrol/ClimateControlHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/climatecontrol/ClimateControlHandler.java
@@ -18,12 +18,20 @@ import org.openhab.binding.boschshc.internal.services.temperaturelevel.Temperatu
 
 import tec.uom.se.unit.Units;
 
+/**
+ * A virtual device which controls up to six Bosch Smart Home radiator thermostats in a room.
+ */
 @NonNullByDefault
 public class ClimateControlHandler extends BoschSHCHandler {
 
     @NonNullByDefault({})
     private RoomClimateControlService roomClimateControlService;
 
+    /**
+     * Constructor.
+     * 
+     * @param thing The Bosch Smart Home device that should be handled.
+     */
     public ClimateControlHandler(Thing thing) {
         super(thing);
     }
@@ -49,11 +57,11 @@ public class ClimateControlHandler extends BoschSHCHandler {
         }
     }
 
-    protected void updateChannels(TemperatureLevelServiceState state) {
+    private void updateChannels(TemperatureLevelServiceState state) {
         super.updateState(CHANNEL_TEMPERATURE, state.getTemperatureState());
     }
 
-    protected void updateChannels(RoomClimateControlServiceState state) {
+    private void updateChannels(RoomClimateControlServiceState state) {
         super.updateState(CHANNEL_SETPOINT_TEMPERATURE, state.getSetpointTemperatureState());
     }
 

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/BoschSHCService.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/BoschSHCService.java
@@ -9,6 +9,10 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.boschshc.internal.BoschSHCBridgeHandler;
 
+/**
+ * Base class of a service of a Bosch Smart Home device.
+ * The services of the devices and their official APIs can be found here: https://apidocs.bosch-smarthome.com/local/
+ */
 @NonNullByDefault
 public abstract class BoschSHCService<TState extends BoschSHCServiceState> {
     /**
@@ -39,6 +43,12 @@ public abstract class BoschSHCService<TState extends BoschSHCServiceState> {
     @Nullable
     private Consumer<TState> stateUpdateListener;
 
+    /**
+     * Constructor
+     * 
+     * @param serviceName Unique name of the service.
+     * @param stateClass State class that this service uses for data transfers from/to the device.
+     */
     protected BoschSHCService(String serviceName, Class<TState> stateClass) {
         this.serviceName = serviceName;
         this.stateClass = stateClass;
@@ -47,10 +57,9 @@ public abstract class BoschSHCService<TState extends BoschSHCServiceState> {
     /**
      * Initializes the service
      * 
-     * @param bridgeHandler       Bridge to use for communication from/to the device
-     * @param deviceId            Id of device this service is for
-     * @param stateUpdateListener Function to call when a state update was received
-     *                            from the device.
+     * @param bridgeHandler Bridge to use for communication from/to the device
+     * @param deviceId Id of device this service is for
+     * @param stateUpdateListener Function to call when a state update was received from the device.
      */
     public void initialize(BoschSHCBridgeHandler bridgeHandler, String deviceId,
             @Nullable Consumer<TState> stateUpdateListener) {
@@ -98,7 +107,7 @@ public abstract class BoschSHCService<TState extends BoschSHCServiceState> {
      * Sets the state of the device with the specified id.
      * 
      * @param deviceId Id of device to set state for.
-     * @param state    State to set.
+     * @param state State to set.
      */
     public void setState(TState state) {
         this.bridgeHandler.putState(this.deviceId, this.serviceName, state);
@@ -115,6 +124,11 @@ public abstract class BoschSHCService<TState extends BoschSHCServiceState> {
         this.onStateUpdate(state);
     }
 
+    /**
+     * A state update was received from the bridge.
+     * 
+     * @param state Current state of service as an instance of the state class.
+     */
     private void onStateUpdate(TState state) {
         Consumer<TState> stateUpdateListener = this.stateUpdateListener;
         if (stateUpdateListener != null) {

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/BoschSHCService.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/BoschSHCService.java
@@ -5,10 +5,11 @@ import java.util.function.Consumer;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.boschshc.internal.BoschSHCBridgeHandler;
 
+@NonNullByDefault
 public abstract class BoschSHCService<TState extends BoschSHCServiceState> {
     /**
      * Unique service name
@@ -23,16 +24,19 @@ public abstract class BoschSHCService<TState extends BoschSHCServiceState> {
     /**
      * Bridge to use for communication from/to the device
      */
+    @NonNullByDefault({})
     private BoschSHCBridgeHandler bridgeHandler;
 
     /**
      * Id of device the service belongs to
      */
+    @NonNullByDefault({})
     private String deviceId;
 
     /**
      * Function to call after receiving state updates from the device
      */
+    @Nullable
     private Consumer<TState> stateUpdateListener;
 
     protected BoschSHCService(String serviceName, Class<TState> stateClass) {
@@ -48,8 +52,8 @@ public abstract class BoschSHCService<TState extends BoschSHCServiceState> {
      * @param stateUpdateListener Function to call when a state update was received
      *                            from the device.
      */
-    public void initialize(@NonNull BoschSHCBridgeHandler bridgeHandler, @NonNull String deviceId,
-            Consumer<TState> stateUpdateListener) {
+    public void initialize(BoschSHCBridgeHandler bridgeHandler, String deviceId,
+            @Nullable Consumer<TState> stateUpdateListener) {
         this.bridgeHandler = bridgeHandler;
         this.deviceId = deviceId;
         this.stateUpdateListener = stateUpdateListener;
@@ -87,7 +91,7 @@ public abstract class BoschSHCService<TState extends BoschSHCServiceState> {
      * @return Current state of the device.
      */
     public @Nullable TState getState() {
-        return this.bridgeHandler.getState(deviceId, this.serviceName, this.stateClass);
+        return this.bridgeHandler.getState(this.deviceId, this.serviceName, this.stateClass);
     }
 
     /**
@@ -96,8 +100,8 @@ public abstract class BoschSHCService<TState extends BoschSHCServiceState> {
      * @param deviceId Id of device to set state for.
      * @param state    State to set.
      */
-    public void setState(@NonNull TState state) {
-        this.bridgeHandler.putState(deviceId, this.serviceName, state);
+    public void setState(TState state) {
+        this.bridgeHandler.putState(this.deviceId, this.serviceName, state);
     }
 
     /**
@@ -105,15 +109,16 @@ public abstract class BoschSHCService<TState extends BoschSHCServiceState> {
      * 
      * @param stateData Current state of service. Serialized as JSON.
      */
-    public void onStateUpdate(@NonNull JsonElement stateData) {
+    public void onStateUpdate(JsonElement stateData) {
         Gson gson = new Gson();
         TState state = gson.fromJson(stateData, this.stateClass);
         this.onStateUpdate(state);
     }
 
     private void onStateUpdate(TState state) {
-        if (this.stateUpdateListener != null) {
-            this.stateUpdateListener.accept(state);
+        Consumer<TState> stateUpdateListener = this.stateUpdateListener;
+        if (stateUpdateListener != null) {
+            stateUpdateListener.accept(state);
         }
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlService.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlService.java
@@ -4,10 +4,15 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.boschshc.internal.services.BoschSHCService;
 
+/**
+ * Service of a virtual device which controls the radiator thermostats in a room.
+ */
 @NonNullByDefault
 public class RoomClimateControlService extends BoschSHCService<@NonNull RoomClimateControlServiceState> {
+    /**
+     * Constructor.
+     */
     public RoomClimateControlService() {
         super("RoomClimateControl", RoomClimateControlServiceState.class);
     }
-
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlService.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlService.java
@@ -1,0 +1,11 @@
+package org.openhab.binding.boschshc.internal.services.roomclimatecontrol;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.openhab.binding.boschshc.internal.services.BoschSHCService;
+
+public class RoomClimateControlService extends BoschSHCService<@NonNull RoomClimateControlServiceState> {
+    public RoomClimateControlService() {
+        super("RoomClimateControl", RoomClimateControlServiceState.class);
+    }
+
+}

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlService.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlService.java
@@ -6,6 +6,8 @@ import org.openhab.binding.boschshc.internal.services.BoschSHCService;
 
 /**
  * Service of a virtual device which controls the radiator thermostats in a room.
+ * 
+ * @author Christian Oeing (christian.oeing@slashgames.org)
  */
 @NonNullByDefault
 public class RoomClimateControlService extends BoschSHCService<@NonNull RoomClimateControlServiceState> {

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlService.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlService.java
@@ -1,8 +1,10 @@
 package org.openhab.binding.boschshc.internal.services.roomclimatecontrol;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.boschshc.internal.services.BoschSHCService;
 
+@NonNullByDefault
 public class RoomClimateControlService extends BoschSHCService<@NonNull RoomClimateControlServiceState> {
     public RoomClimateControlService() {
         super("RoomClimateControl", RoomClimateControlServiceState.class);

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlServiceState.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlServiceState.java
@@ -1,0 +1,18 @@
+package org.openhab.binding.boschshc.internal.services.roomclimatecontrol;
+
+import org.openhab.binding.boschshc.internal.services.BoschSHCServiceState;
+
+public class RoomClimateControlServiceState extends BoschSHCServiceState {
+
+    public RoomClimateControlServiceState() {
+        super("climateControlState");
+    }
+
+    /**
+     * Desired temperature (in degree celsius).
+     * 
+     * @apiNote Min: 5.0, Max: 30.0.
+     * @apiNote Can be set in 0.5 steps.
+     */
+    public Double setpointTemperature;
+}

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlServiceState.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlServiceState.java
@@ -2,12 +2,14 @@ package org.openhab.binding.boschshc.internal.services.roomclimatecontrol;
 
 import javax.measure.quantity.Temperature;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.boschshc.internal.services.BoschSHCServiceState;
 
 import tec.uom.se.unit.Units;
 
+@NonNullByDefault
 public class RoomClimateControlServiceState extends BoschSHCServiceState {
 
     private static final String Type = "climateControlState";

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlServiceState.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlServiceState.java
@@ -9,15 +9,26 @@ import org.openhab.binding.boschshc.internal.services.BoschSHCServiceState;
 
 import tec.uom.se.unit.Units;
 
+/**
+ * State for {@link RoomClimateControlService} to get and set the desired temperature of a room.
+ */
 @NonNullByDefault
 public class RoomClimateControlServiceState extends BoschSHCServiceState {
 
     private static final String Type = "climateControlState";
 
+    /**
+     * Constructor.
+     */
     public RoomClimateControlServiceState() {
         super(Type);
     }
 
+    /**
+     * Constructor.
+     * 
+     * @param setpointTemperature Desired temperature (in degree celsius).
+     */
     public RoomClimateControlServiceState(double setpointTemperature) {
         super(Type);
         this.setpointTemperature = setpointTemperature;

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlServiceState.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlServiceState.java
@@ -1,11 +1,24 @@
 package org.openhab.binding.boschshc.internal.services.roomclimatecontrol;
 
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.boschshc.internal.services.BoschSHCServiceState;
+
+import tec.uom.se.unit.Units;
 
 public class RoomClimateControlServiceState extends BoschSHCServiceState {
 
+    private static final String Type = "climateControlState";
+
     public RoomClimateControlServiceState() {
-        super("climateControlState");
+        super(Type);
+    }
+
+    public RoomClimateControlServiceState(double setpointTemperature) {
+        super(Type);
+        this.setpointTemperature = setpointTemperature;
     }
 
     /**
@@ -14,5 +27,14 @@ public class RoomClimateControlServiceState extends BoschSHCServiceState {
      * @apiNote Min: 5.0, Max: 30.0.
      * @apiNote Can be set in 0.5 steps.
      */
-    public Double setpointTemperature;
+    public double setpointTemperature;
+
+    /**
+     * Desired temperature state to set for a thing.
+     * 
+     * @return Desired temperature state to set for a thing.
+     */
+    public State getSetpointTemperatureState() {
+        return new QuantityType<Temperature>(this.setpointTemperature, Units.CELSIUS);
+    }
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlServiceState.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlServiceState.java
@@ -11,6 +11,8 @@ import tec.uom.se.unit.Units;
 
 /**
  * State for {@link RoomClimateControlService} to get and set the desired temperature of a room.
+ * 
+ * @author Christian Oeing (christian.oeing@slashgames.org)
  */
 @NonNullByDefault
 public class RoomClimateControlServiceState extends BoschSHCServiceState {

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/temperaturelevel/TemperatureLevelService.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/temperaturelevel/TemperatureLevelService.java
@@ -1,8 +1,9 @@
 package org.openhab.binding.boschshc.internal.services.temperaturelevel;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.openhab.binding.boschshc.internal.services.BoschSHCService;
 
-public class TemperatureLevelService extends BoschSHCService<TemperatureLevelServiceState> {
+public class TemperatureLevelService extends BoschSHCService<@NonNull TemperatureLevelServiceState> {
     public TemperatureLevelService() {
         super("TemperatureLevel", TemperatureLevelServiceState.class);
     }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/temperaturelevel/TemperatureLevelServiceState.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/temperaturelevel/TemperatureLevelServiceState.java
@@ -1,6 +1,12 @@
 package org.openhab.binding.boschshc.internal.services.temperaturelevel;
 
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.boschshc.internal.services.BoschSHCServiceState;
+
+import tec.uom.se.unit.Units;
 
 public class TemperatureLevelServiceState extends BoschSHCServiceState {
 
@@ -12,4 +18,13 @@ public class TemperatureLevelServiceState extends BoschSHCServiceState {
      * Current temperature (in degree celsius)
      */
     public double temperature;
+
+    /**
+     * Current temperature state to set for a thing.
+     * 
+     * @return Current temperature state to use for a thing.
+     */
+    public State getTemperatureState() {
+        return new QuantityType<Temperature>(this.temperature, Units.CELSIUS);
+    }
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/valvetappet/ValveTappetService.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/valvetappet/ValveTappetService.java
@@ -1,7 +1,9 @@
 package org.openhab.binding.boschshc.internal.services.valvetappet;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.boschshc.internal.services.BoschSHCService;
 
+@NonNullByDefault
 public class ValveTappetService extends BoschSHCService<ValveTappetServiceState> {
     public ValveTappetService() {
         super("ValveTappet", ValveTappetServiceState.class);

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/valvetappet/ValveTappetServiceState.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/valvetappet/ValveTappetServiceState.java
@@ -1,5 +1,7 @@
 package org.openhab.binding.boschshc.internal.services.valvetappet;
 
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.boschshc.internal.services.BoschSHCServiceState;
 
 public class ValveTappetServiceState extends BoschSHCServiceState {
@@ -11,4 +13,11 @@ public class ValveTappetServiceState extends BoschSHCServiceState {
      * Current open percentage of valve tappet (0 [closed] - 100 [open]).
      */
     public Integer position;
+
+    /**
+     * Current position state of valve tappet.
+     */
+    public State getPositionState() {
+        return new DecimalType(this.position);
+    }
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/shuttercontrol/ShutterControlHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/shuttercontrol/ShutterControlHandler.java
@@ -92,17 +92,11 @@ public class ShutterControlHandler extends BoschSHCHandler {
 
     private @Nullable ShutterControlState getDeviceState() {
         BoschSHCBridgeHandler bridgeHandler = this.getBridgeHandler();
-        if (bridgeHandler == null) {
-            return null;
-        }
         return bridgeHandler.refreshState(getThing(), ShutterControlServiceName, ShutterControlState.class);
     }
 
     private void setDeviceState(ShutterControlState state) {
         BoschSHCBridgeHandler bridgeHandler = this.getBridgeHandler();
-        if (bridgeHandler == null) {
-            return;
-        }
         String deviceId = this.getBoschID();
         if (deviceId == null) {
             return;

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/thermostat/ThermostatHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/thermostat/ThermostatHandler.java
@@ -1,13 +1,10 @@
 package org.openhab.binding.boschshc.internal.thermostat;
 
-import static org.openhab.binding.boschshc.internal.BoschSHCBindingConstants.*;
+import static org.openhab.binding.boschshc.internal.BoschSHCBindingConstants.CHANNEL_TEMPERATURE;
+import static org.openhab.binding.boschshc.internal.BoschSHCBindingConstants.CHANNEL_VALVE_TAPPET_POSITION;
 
 import java.util.Arrays;
 
-import javax.measure.quantity.Temperature;
-
-import org.eclipse.smarthome.core.library.types.DecimalType;
-import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.openhab.binding.boschshc.internal.BoschSHCBridgeHandler;
 import org.openhab.binding.boschshc.internal.BoschSHCHandler;
@@ -15,8 +12,6 @@ import org.openhab.binding.boschshc.internal.services.temperaturelevel.Temperatu
 import org.openhab.binding.boschshc.internal.services.temperaturelevel.TemperatureLevelServiceState;
 import org.openhab.binding.boschshc.internal.services.valvetappet.ValveTappetService;
 import org.openhab.binding.boschshc.internal.services.valvetappet.ValveTappetServiceState;
-
-import tec.uom.se.unit.Units;
 
 public class ThermostatHandler extends BoschSHCHandler {
 

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/thermostat/ThermostatHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/thermostat/ThermostatHandler.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.Thing;
-import org.openhab.binding.boschshc.internal.BoschSHCBridgeHandler;
 import org.openhab.binding.boschshc.internal.BoschSHCHandler;
 import org.openhab.binding.boschshc.internal.services.temperaturelevel.TemperatureLevelService;
 import org.openhab.binding.boschshc.internal.services.temperaturelevel.TemperatureLevelServiceState;
@@ -24,11 +23,6 @@ public final class ThermostatHandler extends BoschSHCHandler {
     @Override
     public void initialize() {
         super.initialize();
-
-        BoschSHCBridgeHandler bridgeHandler = this.getBridgeHandler();
-        if (bridgeHandler == null) {
-            throw new Error(String.format("Could not initialize {}, no valid bridge set", this.getThing()));
-        }
 
         // Initialize services
         this.createService(TemperatureLevelService.class, this::updateChannels, Arrays.asList(CHANNEL_TEMPERATURE));

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/thermostat/ThermostatHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/thermostat/ThermostatHandler.java
@@ -5,6 +5,7 @@ import static org.openhab.binding.boschshc.internal.BoschSHCBindingConstants.CHA
 
 import java.util.Arrays;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.openhab.binding.boschshc.internal.BoschSHCBridgeHandler;
 import org.openhab.binding.boschshc.internal.BoschSHCHandler;
@@ -13,11 +14,8 @@ import org.openhab.binding.boschshc.internal.services.temperaturelevel.Temperatu
 import org.openhab.binding.boschshc.internal.services.valvetappet.ValveTappetService;
 import org.openhab.binding.boschshc.internal.services.valvetappet.ValveTappetServiceState;
 
-public class ThermostatHandler extends BoschSHCHandler {
-
-    private TemperatureLevelService temperatureLevelService;
-
-    private ValveTappetService valveTappetService;
+@NonNullByDefault
+public final class ThermostatHandler extends BoschSHCHandler {
 
     public ThermostatHandler(Thing thing) {
         super(thing);
@@ -33,21 +31,25 @@ public class ThermostatHandler extends BoschSHCHandler {
         }
 
         // Initialize services
-        String deviceId = this.getBoschID();
-
-        this.temperatureLevelService = new TemperatureLevelService();
-        this.temperatureLevelService.initialize(bridgeHandler, deviceId, this::updateChannels);
-        this.registerService(this.temperatureLevelService, Arrays.asList(CHANNEL_TEMPERATURE));
-
-        this.valveTappetService = new ValveTappetService();
-        this.valveTappetService.initialize(bridgeHandler, deviceId, this::updateChannels);
-        this.registerService(this.valveTappetService, Arrays.asList(CHANNEL_VALVE_TAPPET_POSITION));
+        this.createService(TemperatureLevelService.class, this::updateChannels, Arrays.asList(CHANNEL_TEMPERATURE));
+        this.createService(ValveTappetService.class, this::updateChannels,
+                Arrays.asList(CHANNEL_VALVE_TAPPET_POSITION));
     }
 
-    protected void updateChannels(TemperatureLevelServiceState state) {
+    /**
+     * Updates the channels which are linked to the {@link TemperatureLevelService} of the device.
+     * 
+     * @param state Current state of {@link TemperatureLevelService}.
+     */
+    private void updateChannels(TemperatureLevelServiceState state) {
         super.updateState(CHANNEL_TEMPERATURE, state.getTemperatureState());
     }
 
+    /**
+     * Updates the channels which are linked to the {@link ValveTappetService} of the device.
+     * 
+     * @param state Current state of {@link ValveTappetService}.
+     */
     private void updateChannels(ValveTappetServiceState state) {
         super.updateState(CHANNEL_VALVE_TAPPET_POSITION, state.getPositionState());
     }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/thermostat/ThermostatHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/thermostat/ThermostatHandler.java
@@ -4,7 +4,10 @@ import static org.openhab.binding.boschshc.internal.BoschSHCBindingConstants.*;
 
 import java.util.Arrays;
 
+import javax.measure.quantity.Temperature;
+
 import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.openhab.binding.boschshc.internal.BoschSHCBridgeHandler;
 import org.openhab.binding.boschshc.internal.BoschSHCHandler;
@@ -12,6 +15,8 @@ import org.openhab.binding.boschshc.internal.services.temperaturelevel.Temperatu
 import org.openhab.binding.boschshc.internal.services.temperaturelevel.TemperatureLevelServiceState;
 import org.openhab.binding.boschshc.internal.services.valvetappet.ValveTappetService;
 import org.openhab.binding.boschshc.internal.services.valvetappet.ValveTappetServiceState;
+
+import tec.uom.se.unit.Units;
 
 public class ThermostatHandler extends BoschSHCHandler {
 
@@ -45,10 +50,10 @@ public class ThermostatHandler extends BoschSHCHandler {
     }
 
     protected void updateChannels(TemperatureLevelServiceState state) {
-        super.updateState(CHANNEL_TEMPERATURE, new DecimalType(state.temperature));
+        super.updateState(CHANNEL_TEMPERATURE, state.getTemperatureState());
     }
 
     private void updateChannels(ValveTappetServiceState state) {
-        super.updateState(CHANNEL_VALVE_TAPPET_POSITION, new DecimalType(state.position));
+        super.updateState(CHANNEL_VALVE_TAPPET_POSITION, state.getPositionState());
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.boschshc/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -150,6 +150,29 @@
 
     </thing-type>
 
+    <thing-type id="climate-control">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="shc" />
+        </supported-bridge-type-refs>
+
+        <label>Climate Control</label>
+        <description>Bosch Climate Control. This is a virtual device which is automatically created for all rooms that have thermostats in it.</description>
+
+        <channels>
+            <channel id="temperature" typeId="temperature" />
+            <channel id="setpoint-temperature" typeId="setpoint-temperature" />
+        </channels>
+
+        <config-description>
+            <parameter name="id" type="text" required="true">
+                <label>Device ID</label>
+                <description>Device ID of the climate control</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+
+    </thing-type>
+
     <!-- https://www.eclipse.org/smarthome/documentation/concepts/items.html -->
     <channel-type id="power-switch">
         <item-type>Switch</item-type>
@@ -242,6 +265,13 @@
         <label>Valve Tappet Position</label>
         <description>Current open ratio (0 to 100).</description>
         <state min="0" max="100" step="1" readOnly="true" />
+    </channel-type>
+
+    <channel-type id="setpoint-temperature">
+        <item-type>Number:Temperature</item-type>
+        <label>Setpoint Temperature</label>
+        <description>Desired temperature (in degree celsius).</description>
+        <state min="5" max="30" step="0.5" pattern="%.1f °C" />
     </channel-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
Started to add the handling for the "virtual" climate control devices. As it seems they are created automatically by the Bosch home controller for each room with a thermostat in it.

They are used to set the desired temperature (setpoint temperature) for a room and they report the temperature of a room (probably the average temperature of all thermostat temperatures in the room).

- [x] Documentation for all new classes
- [x] Make registerService private and change the usages in derived classes to use createService instead
- [x] Throw Error instead of returning Null in getBridgeHandler to avoid unnessesary null reference checks after initialization
- [x] Add @author tags to new classes