### PR TITLE
Handle error response of state requests of device services

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCBridgeHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCBridgeHandler.java
@@ -477,7 +477,8 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
             contentResponse = request.send();
 
             String content = contentResponse.getContentAsString();
-            logger.debug("refreshState: Request complete: [{}] - return code: {}", content, contentResponse.getStatus());
+            logger.debug("refreshState: Request complete: [{}] - return code: {}", content,
+                    contentResponse.getStatus());
 
             Gson gson = new GsonBuilder().create();
 

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCBridgeHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/BoschSHCBridgeHandler.java
@@ -40,8 +40,10 @@ import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.boschshc.internal.exceptions.PairingFailedException;
+import org.openhab.binding.boschshc.internal.services.JsonRestExceptionResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.MessageFormatter;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -467,24 +469,26 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
     public <T extends @NonNull Object> @Nullable T getState(String deviceId, String stateName, Class<T> stateClass) {
         ContentResponse contentResponse;
         try {
-
-            String url = "https://" + config.ipAddress + ":8444/smarthome/devices/" + deviceId + "/services/"
-                    + stateName + "/state";
+            String url = this.createServiceUrl(stateName, deviceId);
+            Request request = this.createRequest(httpClient, url, GET).header("Accept", "application/json");
 
             logger.debug("refreshState: Requesting \"{}\" from Bosch: {} via {}", stateName, deviceId, url);
 
-            // GET request
-            // ----------------------------------------------------------------------------------
-
-            // TODO: Gateway ID is hard-coded!
-            contentResponse = httpClient.newRequest(url).header("Content-Type", "application/json")
-                    .header("Accept", "application/json").header("Gateway-ID", "64-DA-A0-02-14-9B").method(GET).send();
+            contentResponse = request.send();
 
             String content = contentResponse.getContentAsString();
             logger.debug("refreshState: Request complete: [{}] - return code: {}", content, contentResponse.getStatus());
 
-            // TODO Perhaps we should have only one single gson builder per thing?
             Gson gson = new GsonBuilder().create();
+
+            int statusCode = contentResponse.getStatus();
+            if (statusCode != 200) {
+                JsonRestExceptionResponse errorResponse = gson.fromJson(content, JsonRestExceptionResponse.class);
+                throw new Error(MessageFormatter.arrayFormat(
+                        "State request for service {} of device {} failed with status code {} and error code {}",
+                        new Object[] { stateName, deviceId, errorResponse.statusCode, errorResponse.errorCode })
+                        .getMessage());
+            }
 
             T state = gson.fromJson(content, stateClass);
             return state;
@@ -570,10 +574,17 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
                 + "/state";
     }
 
-    private Request createRequest(BoschHttpClient httpClient, String url, HttpMethod method, Object content) {
+    private Request createRequest(BoschHttpClient httpClient, String url, HttpMethod method) {
+        return this.createRequest(httpClient, url, method, null);
+    }
+
+    private Request createRequest(BoschHttpClient httpClient, String url, HttpMethod method, @Nullable Object content) {
         Gson gson = new Gson();
-        String body = gson.toJson(content);
-        return httpClient.newRequest(url).method(method).header("Content-Type", "application/json")
-                .content(new StringContentProvider(body));
+        Request request = httpClient.newRequest(url).method(method).header("Content-Type", "application/json");
+        if (content != null) {
+            String body = gson.toJson(content);
+            request = request.content(new StringContentProvider(body));
+        }
+        return request;
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/climatecontrol/ClimateControlHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/climatecontrol/ClimateControlHandler.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.boschshc.internal.devices.climatecontrol;
 
 import static org.openhab.binding.boschshc.internal.BoschSHCBindingConstants.CHANNEL_SETPOINT_TEMPERATURE;

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/JsonRestExceptionResponse.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/JsonRestExceptionResponse.java
@@ -1,0 +1,17 @@
+package org.openhab.binding.boschshc.internal.services;
+
+public class JsonRestExceptionResponse extends BoschSHCServiceState {
+    public JsonRestExceptionResponse() {
+        super("JsonRestExceptionResponseEntity");
+    }
+
+    /**
+     * The error code of the occurred Exception.
+     */
+    public String errorCode;
+
+    /**
+     * The HTTP status of the error.
+     */
+    public int statusCode;
+}

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/JsonRestExceptionResponse.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/JsonRestExceptionResponse.java
@@ -1,5 +1,22 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.boschshc.internal.services;
 
+/**
+ * Generic error response of the Bosch REST API.
+ * 
+ * @author Christian Oeing (christian.oeing@slashgames.org)
+ */
 public class JsonRestExceptionResponse extends BoschSHCServiceState {
     public JsonRestExceptionResponse() {
         super("JsonRestExceptionResponseEntity");

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlService.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlService.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.boschshc.internal.services.roomclimatecontrol;
 
 import org.eclipse.jdt.annotation.NonNull;

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlServiceState.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/roomclimatecontrol/RoomClimateControlServiceState.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.boschshc.internal.services.roomclimatecontrol;
 
 import javax.measure.quantity.Temperature;


### PR DESCRIPTION
Closes #24 

To handle the reason of the error response in #24 I added a new issue (#34). This pull request only handles error responses during a state request in general.