### PR TITLE
Correctly check if long poll response is valid

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/LongPolling.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/LongPolling.java
@@ -177,16 +177,17 @@ public class LongPolling {
         String nextSubscriptionId = subscriptionId;
 
         LongPollResult longPollResult = gson.fromJson(content, LongPollResult.class);
-        if (longPollResult != null) {
+        if (longPollResult != null && longPollResult.result != null) {
             this.handleResult.accept(longPollResult);
         } else {
-            logger.warn("Could not parse long poll response: {}", content);
+            logger.warn("Long poll response contained no results: {}", content);
 
             // Check if we got a proper result from the SHC
             LongPollError longPollError = gson.fromJson(content, LongPollError.class);
 
-            if (longPollError != null) {
-                logger.warn("Got error from SHC: {} (code: {})", longPollError.error.message, longPollError.error.code);
+            if (longPollError != null && longPollError.error != null) {
+                logger.warn("Got long poll error: {} (code: {})", longPollError.error.message,
+                        longPollError.error.code);
 
                 if (longPollError.error.code == LongPollError.SUBSCRIPTION_INVALID) {
                     logger.warn("Subscription {} became invalid, subscribing again", subscriptionId);

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/dto/LongPollResultTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/dto/LongPollResultTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschshc.internal.devices.bridge.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+
+/**
+ * Unit tests for LongPollResult
+ *
+ * @author Christian Oeing - Initial contribution
+ */
+public class LongPollResultTest {
+    private final Gson gson = new Gson();
+
+    @Test
+    public void NoResultsForErrorResult() {
+        LongPollResult longPollResult = gson.fromJson(
+                "{\"jsonrpc\":\"2.0\", \"error\": { \"code\":-32001, \"message\":\"No subscription with id: e8fei62b0-0\" } }",
+                LongPollResult.class);
+        assertEquals(null, longPollResult.result);
+    }
+}

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/dto/LongPollResultTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/dto/LongPollResultTest.java
@@ -13,7 +13,9 @@
 package org.openhab.binding.boschshc.internal.devices.bridge.dto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
 import com.google.gson.Gson;
@@ -23,14 +25,18 @@ import com.google.gson.Gson;
  *
  * @author Christian Oeing - Initial contribution
  */
+@NonNullByDefault
 public class LongPollResultTest {
     private final Gson gson = new Gson();
 
     @Test
-    public void NoResultsForErrorResult() {
+    public void noResultsForErrorResult() {
         LongPollResult longPollResult = gson.fromJson(
                 "{\"jsonrpc\":\"2.0\", \"error\": { \"code\":-32001, \"message\":\"No subscription with id: e8fei62b0-0\" } }",
                 LongPollResult.class);
-        assertEquals(null, longPollResult.result);
+        assertNotEquals(null, longPollResult);
+        if (longPollResult != null) {
+            assertEquals(null, longPollResult.result);
+        }
     }
 }


### PR DESCRIPTION
GSON will not return null if there is no "result" field, but will just set the "result" member to null. So we have to check both.

This should fix the issue #62 as the long polling is already restarted when the long poll error about an invalid subscription arrives.