### PR TITLE
Feature/#55 key store and password

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClient.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClient.java
@@ -136,12 +136,12 @@ public class BoschHttpClient extends HttpClient {
         ContentResponse contentResponse;
         try {
             String publicCert = getCertFromSslContextFactory();
-            logger.trace("Pairing this Client '{}' with SHC {}", BoschSslUtil.getBoschSHCId(), ipAddress);
+            logger.trace("Pairing with SHC {}", ipAddress);
 
             // JSON Rest content
             Map<String, String> items = new HashMap<>();
             items.put("@type", "client");
-            items.put("id", BoschSslUtil.getBoschSHCId()); // Client Id contains the unique OpenHab instance Id
+            items.put("id", BoschSslUtil.getBoschShcClientId()); // Client Id contains the unique OpenHab instance Id
             items.put("name", "oss_OpenHAB_Binding"); // Client name according to
                                                       // https://github.com/BoschSmartHome/bosch-shc-api-docs#terms-and-conditions
             items.put("primaryRole", "ROLE_RESTRICTED_CLIENT");
@@ -240,7 +240,8 @@ public class BoschHttpClient extends HttpClient {
     }
 
     private String getCertFromSslContextFactory() throws KeyStoreException, CertificateEncodingException {
-        Certificate cert = this.getSslContextFactory().getKeyStore().getCertificate(BoschSslUtil.getBoschSHCId());
+        Certificate cert = this.getSslContextFactory().getKeyStore()
+                .getCertificate(BoschSslUtil.getBoschShcServerId(ipAddress));
         return Base64.getEncoder().encodeToString(cert.getEncoded());
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSHCBridgeHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSHCBridgeHandler.java
@@ -99,7 +99,7 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
         SslContextFactory factory;
         try {
             // prepare SSL key and certificates
-            factory = new BoschSslUtil(config.password).getSslContextFactory();
+            factory = new BoschSslUtil(config.ipAddress).getSslContextFactory();
         } catch (PairingFailedException e) {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
                     "@text/offline.conf-error-ssl");

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSHCBridgeHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSHCBridgeHandler.java
@@ -223,7 +223,7 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
 
         try {
             logger.debug("Sending http request to Bosch to request clients: {}", httpClient);
-            String url = httpClient.createSmartHomeUrl("devices");
+            String url = httpClient.getBoschSmartHomeUrl("devices");
             ContentResponse contentResponse = httpClient.createRequest(url, GET).send();
 
             String content = contentResponse.getContentAsString();
@@ -301,7 +301,7 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
         if (httpClient != null) {
             try {
                 logger.debug("Sending http request to Bosch to request rooms");
-                String url = httpClient.createSmartHomeUrl("rooms");
+                String url = httpClient.getBoschSmartHomeUrl("rooms");
                 ContentResponse contentResponse = httpClient.createRequest(url, GET).send();
 
                 String content = contentResponse.getContentAsString();
@@ -347,7 +347,7 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
             return null;
         }
 
-        String url = httpClient.createServiceUrl(stateName, deviceId);
+        String url = httpClient.getServiceUrl(stateName, deviceId);
         Request request = httpClient.createRequest(url, GET).header("Accept", "application/json");
 
         logger.debug("refreshState: Requesting \"{}\" from Bosch: {} via {}", stateName, deviceId, url);
@@ -400,7 +400,7 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
         }
 
         // Create request
-        String url = httpClient.createServiceUrl(serviceName, deviceId);
+        String url = httpClient.getServiceUrl(serviceName, deviceId);
         Request request = httpClient.createRequest(url, PUT, state);
 
         // Send request

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSslUtil.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSslUtil.java
@@ -67,6 +67,7 @@ public class BoschSslUtil {
     public static String getBoschSHCId() {
         return OSS_OPENHAB_BINDING + "_" + InstanceUUID.get();
     }
+
     public static String getKeystorePath() {
         return Paths.get(OpenHAB.getUserDataFolder(), "etc", getBoschSHCId() + ".jks").toString();
     }
@@ -107,7 +108,9 @@ public class BoschSslUtil {
             } else {
                 // load keystore as a first check
                 KeyStore keyStore = KeyStore.getInstance("JKS");
-                keyStore.load(new FileInputStream(file), keystorePassword.toCharArray());
+                try (FileInputStream streamKeystore = new FileInputStream(file)) {
+                    keyStore.load(streamKeystore, keystorePassword.toCharArray());
+                }
                 logger.debug("Using existing keystore {}", keystorePath);
                 return keyStore;
             }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSslUtil.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSslUtil.java
@@ -61,15 +61,18 @@ public class BoschSslUtil {
 
     private final Logger logger = LoggerFactory.getLogger(BoschSslUtil.class);
 
-    private String keystorePath;
-    private String keystorePassword;
+    private final String keystorePath;
+    private final String keystorePassword;
 
     public static String getBoschSHCId() {
         return OSS_OPENHAB_BINDING + "_" + InstanceUUID.get();
     }
+    public static String getKeystorePath() {
+        return Paths.get(OpenHAB.getUserDataFolder(), "etc", getBoschSHCId() + ".jks").toString();
+    }
 
     public BoschSslUtil(String keystorePassword) {
-        this.keystorePath = Paths.get(OpenHAB.getUserDataFolder(), "etc", getBoschSHCId() + ".jks").toString();
+        this.keystorePath = getKeystorePath();
         this.keystorePassword = keystorePassword;
     }
 
@@ -177,7 +180,7 @@ public class BoschSslUtil {
         }
 
         logger.debug("Storing keystore to file {}", keystore);
-        try (FileOutputStream streamKeystore = new FileOutputStream(new File(keystore))) {
+        try (FileOutputStream streamKeystore = new FileOutputStream(keystore)) {
             keyStore.store(streamKeystore, keystorePassword.toCharArray());
         }
 

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/LongPolling.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/LongPolling.java
@@ -106,7 +106,7 @@ public class LongPolling {
      */
     private String subscribe(BoschHttpClient httpClient) throws LongPollingFailedException {
         try {
-            String url = httpClient.createUrl("remote/json-rpc");
+            String url = httpClient.getBoschShcUrl("remote/json-rpc");
             JsonRpcRequest request = new JsonRpcRequest("2.0", "RE/subscribe",
                     new String[] { "com/bosch/sh/remote/*", null });
             logger.debug("Subscribe: Sending request: {} - using httpClient {}", gson.toJson(request), httpClient);
@@ -132,7 +132,7 @@ public class LongPolling {
         logger.debug("Sending long poll request");
 
         JsonRpcRequest requestContent = new JsonRpcRequest("2.0", "RE/longPoll", new String[] { subscriptionId, "20" });
-        String url = httpClient.createUrl("remote/json-rpc");
+        String url = httpClient.getBoschShcUrl("remote/json-rpc");
         Request request = httpClient.createRequest(url, POST, requestContent);
 
         // Long polling responds after 20 seconds with an empty response if no update has happened.

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClientTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClientTest.java
@@ -14,6 +14,8 @@ package org.openhab.binding.boschshc.internal.devices.bridge;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -31,6 +33,7 @@ import org.openhab.binding.boschshc.internal.exceptions.PairingFailedException;
 @NonNullByDefault
 class BoschHttpClientTest {
 
+    @Nullable
     private BoschHttpClient httpClient;
 
     @BeforeAll
@@ -40,8 +43,9 @@ class BoschHttpClientTest {
 
     @BeforeEach
     void beforeEach() throws PairingFailedException {
-        SslContextFactory sslFactory = new BoschSslUtil("dummy").getSslContextFactory();
+        SslContextFactory sslFactory = new BoschSslUtil("127.0.0.1").getSslContextFactory();
         httpClient = new BoschHttpClient("127.0.0.1", "dummy", sslFactory);
+        assertNotNull(httpClient);
     }
 
     @Test

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClientTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClientTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschshc.internal.devices.bridge;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.boschshc.internal.devices.bridge.dto.SubscribeResult;
+import org.openhab.binding.boschshc.internal.exceptions.PairingFailedException;
+
+/**
+ * Tests cases for {@link BoschHttpClient}.
+ *
+ * @author Gerd Zanker - Initial contribution
+ */
+@NonNullByDefault
+class BoschHttpClientTest {
+
+    private BoschHttpClient httpClient;
+
+    @BeforeAll
+    static void beforeAll() {
+        BoschSslUtilTest.prepareTempFolderForKeyStore();
+    }
+
+    @BeforeEach
+    void beforeEach() throws PairingFailedException {
+        SslContextFactory sslFactory = new BoschSslUtil("dummy").getSslContextFactory();
+        httpClient = new BoschHttpClient("127.0.0.1", "dummy", sslFactory);
+    }
+
+    @Test
+    void getPairingUrl() {
+        assertEquals("https://127.0.0.1:8443/smarthome/clients", httpClient.getPairingUrl());
+    }
+
+    @Test
+    void getBoschShcUrl() {
+        assertEquals("https://127.0.0.1:8444/testEndpoint", httpClient.getBoschShcUrl("testEndpoint"));
+    }
+
+    @Test
+    void getBoschSmartHomeUrl() {
+        assertEquals("https://127.0.0.1:8444/smarthome/endpointForTest",
+                httpClient.getBoschSmartHomeUrl("endpointForTest"));
+    }
+
+    @Test
+    void getServiceUrl() {
+        assertEquals("https://127.0.0.1:8444/smarthome/devices/testDevice/services/testService/state",
+                httpClient.getServiceUrl("testService", "testDevice"));
+    }
+
+    @Test
+    void isAccessPossible() throws InterruptedException {
+        assertFalse(httpClient.isAccessPossible());
+    }
+
+    @Test
+    void doPairing() throws InterruptedException {
+        assertFalse(httpClient.doPairing());
+    }
+
+    @Test
+    void createRequest() {
+        Request request = httpClient.createRequest("https://127.0.0.1", HttpMethod.GET);
+        assertNotNull(request);
+    }
+
+    @Test
+    void createRequestWithObject() {
+        Request request = httpClient.createRequest("https://127.0.0.1", HttpMethod.GET, "someData");
+        assertNotNull(request);
+    }
+
+    @Test
+    void sendRequest() {
+        Request request = httpClient.createRequest("https://127.0.0.1", HttpMethod.GET);
+        // Null pointer exception is expected, because localhost will not answer request
+        assertThrows(NullPointerException.class, () -> {
+            httpClient.sendRequest(request, SubscribeResult.class);
+        });
+    }
+}

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSslUtilTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSslUtilTest.java
@@ -1,16 +1,28 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.boschshc.internal.devices.bridge;
 
 import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.security.KeyStore;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.boschshc.internal.exceptions.PairingFailedException;
-
-import java.io.File;
-import java.nio.file.Paths;
-import java.security.KeyStore;
 
 /**
  * Tests cases for {@link BoschSslUtil}.
@@ -21,21 +33,21 @@ import java.security.KeyStore;
 class BoschSslUtilTest {
 
     @BeforeAll
-    static void before() {
-        // Use temp folder for userdata folder
-        String tmpDir = System.getProperty("java.io.tmpdir");
-        System.setProperty("openhab.userdata", tmpDir != null ? tmpDir : "/tmp");
+    static void beforeAll() {
+        prepareTempFolderForKeyStore();
     }
 
-    private void prepareTempDir() {
+    public static void prepareTempFolderForKeyStore() {
+        // Use temp folder for userdata folder
         String tmpDir = System.getProperty("java.io.tmpdir");
         tmpDir = tmpDir != null ? tmpDir : "/tmp";
+        System.setProperty("openhab.userdata", tmpDir);
+        // prepare temp folder on local drive
         File tempDir = Paths.get(tmpDir, "etc").toFile();
-        if (!tempDir.exists()){
+        if (!tempDir.exists()) {
             assertTrue(tempDir.mkdirs());
         }
     }
-
 
     @Test
     void getBoschSHCId() {
@@ -53,12 +65,11 @@ class BoschSslUtilTest {
      */
     @Test
     void keyStoreAndFactory() throws PairingFailedException {
-        prepareTempDir();
 
         // remote old, existing jks
         File keyStoreFile = new File(BoschSslUtil.getKeystorePath());
         keyStoreFile.deleteOnExit();
-        if(keyStoreFile.exists()) {
+        if (keyStoreFile.exists()) {
             assertTrue(keyStoreFile.delete());
         }
 
@@ -79,5 +90,4 @@ class BoschSslUtilTest {
         SslContextFactory factory = sslUtil.getSslContextFactory();
         assertNotNull(factory);
     }
-
 }

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSslUtilTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSslUtilTest.java
@@ -50,14 +50,22 @@ class BoschSslUtilTest {
     }
 
     @Test
-    void getBoschSHCId() {
+    void getBoschShcClientId() {
         // OpenSource Bosch SHC clients needs start with oss
-        assertTrue(BoschSslUtil.getBoschSHCId().startsWith("oss"));
+        assertTrue(BoschSslUtil.getBoschShcClientId().startsWith("oss"));
+    }
+
+    @Test
+    void getBoschShcServerId() {
+        // OpenSource Bosch SHC clients needs start with oss
+        assertTrue(BoschSslUtil.getBoschShcServerId("localhost").startsWith("oss"));
+        assertTrue(BoschSslUtil.getBoschShcServerId("localhost").contains("localhost"));
     }
 
     @Test
     void getKeystorePath() {
-        assertTrue(BoschSslUtil.getKeystorePath().endsWith(".jks"));
+        BoschSslUtil sslUtil = new BoschSslUtil("123.45.67.89");
+        assertTrue(sslUtil.getKeystorePath().endsWith(".jks"));
     }
 
     /**
@@ -65,9 +73,10 @@ class BoschSslUtilTest {
      */
     @Test
     void keyStoreAndFactory() throws PairingFailedException {
+        BoschSslUtil sslUtil1 = new BoschSslUtil("127.0.0.1");
 
         // remote old, existing jks
-        File keyStoreFile = new File(BoschSslUtil.getKeystorePath());
+        File keyStoreFile = new File(sslUtil1.getKeystorePath());
         keyStoreFile.deleteOnExit();
         if (keyStoreFile.exists()) {
             assertTrue(keyStoreFile.delete());
@@ -75,19 +84,19 @@ class BoschSslUtilTest {
 
         assertFalse(keyStoreFile.exists());
 
-        BoschSslUtil sslUtil = new BoschSslUtil("pwd");
+        BoschSslUtil sslUtil2 = new BoschSslUtil("127.0.0.1");
         // fist call where keystore is created
-        KeyStore keyStore = sslUtil.getKeyStoreAndCreateIfNecessary();
+        KeyStore keyStore = sslUtil2.getKeyStoreAndCreateIfNecessary();
         assertNotNull(keyStore);
 
         assertTrue(keyStoreFile.exists());
 
         // second call where keystore is reopened
-        KeyStore keyStore2 = sslUtil.getKeyStoreAndCreateIfNecessary();
+        KeyStore keyStore2 = sslUtil2.getKeyStoreAndCreateIfNecessary();
         assertNotNull(keyStore2);
 
         // basic test if a SSL factory instance can be created
-        SslContextFactory factory = sslUtil.getSslContextFactory();
+        SslContextFactory factory = sslUtil2.getSslContextFactory();
         assertNotNull(factory);
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSslUtilTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSslUtilTest.java
@@ -1,0 +1,83 @@
+package org.openhab.binding.boschshc.internal.devices.bridge;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.boschshc.internal.exceptions.PairingFailedException;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+
+/**
+ * Tests cases for {@link BoschSslUtil}.
+ *
+ * @author Gerd Zanker - Initial contribution
+ */
+@NonNullByDefault
+class BoschSslUtilTest {
+
+    @BeforeAll
+    static void before() {
+        // Use temp folder for userdata folder
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        System.setProperty("openhab.userdata", tmpDir != null ? tmpDir : "/tmp");
+    }
+
+    private void prepareTempDir() {
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        tmpDir = tmpDir != null ? tmpDir : "/tmp";
+        File tempDir = Paths.get(tmpDir, "etc").toFile();
+        if (!tempDir.exists()){
+            assertTrue(tempDir.mkdirs());
+        }
+    }
+
+
+    @Test
+    void getBoschSHCId() {
+        // OpenSource Bosch SHC clients needs start with oss
+        assertTrue(BoschSslUtil.getBoschSHCId().startsWith("oss"));
+    }
+
+    @Test
+    void getKeystorePath() {
+        assertTrue(BoschSslUtil.getKeystorePath().endsWith(".jks"));
+    }
+
+    /**
+     * Test if the keyStore can be created if it doesn't exist.
+     */
+    @Test
+    void keyStoreAndFactory() throws PairingFailedException {
+        prepareTempDir();
+
+        // remote old, existing jks
+        File keyStoreFile = new File(BoschSslUtil.getKeystorePath());
+        keyStoreFile.deleteOnExit();
+        if(keyStoreFile.exists()) {
+            assertTrue(keyStoreFile.delete());
+        }
+
+        assertFalse(keyStoreFile.exists());
+
+        BoschSslUtil sslUtil = new BoschSslUtil("pwd");
+        // fist call where keystore is created
+        KeyStore keyStore = sslUtil.getKeyStoreAndCreateIfNecessary();
+        assertNotNull(keyStore);
+
+        assertTrue(keyStoreFile.exists());
+
+        // second call where keystore is reopened
+        KeyStore keyStore2 = sslUtil.getKeyStoreAndCreateIfNecessary();
+        assertNotNull(keyStore2);
+
+        // basic test if a SSL factory instance can be created
+        SslContextFactory factory = sslUtil.getSslContextFactory();
+        assertNotNull(factory);
+    }
+
+}


### PR DESCRIPTION
Solves password issue #55 
Replaced the password with a fixed 

The changeable SHC system password for the keystore is replaced by a static string in the code.
The keyStore name is now based on SHC ipAddress to support multiple SmartHomeControllers.