### PR TITLE
Restart long polling correctly when it fails

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClient.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClient.java
@@ -194,6 +194,8 @@ public class BoschHttpClient extends HttpClient {
      * @return created HTTP request instance
      */
     public Request createRequest(String url, HttpMethod method, @Nullable Object content) {
+        logger.trace(String.format("Create request for http client %s", this.toString()));
+
         Request request = this.newRequest(url).method(method).header("Content-Type", "application/json");
         if (content != null) {
             String body = GSON.toJson(content);
@@ -220,9 +222,11 @@ public class BoschHttpClient extends HttpClient {
      */
     public <TContent> TContent sendRequest(Request request, Class<TContent> responseContentClass)
             throws InterruptedException, TimeoutException, ExecutionException {
+        logger.trace("Send request: {}", request.toString());
+
         ContentResponse contentResponse = request.send();
 
-        logger.debug("BoschHttpClient: response complete: {} - return code: {}", contentResponse.getContentAsString(),
+        logger.debug("Received response: {} - status: {}", contentResponse.getContentAsString(),
                 contentResponse.getStatus());
 
         try {

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClient.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClient.java
@@ -194,7 +194,7 @@ public class BoschHttpClient extends HttpClient {
      * @return created HTTP request instance
      */
     public Request createRequest(String url, HttpMethod method, @Nullable Object content) {
-        logger.trace(String.format("Create request for http client %s", this.toString()));
+        logger.trace("Create request for http client {}", this.toString());
 
         Request request = this.newRequest(url).method(method).header("Content-Type", "application/json");
         if (content != null) {

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSHCBridgeHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSHCBridgeHandler.java
@@ -291,12 +291,12 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
         BoschHttpClient httpClient = this.httpClient;
         if (httpClient == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
-                    "Long polling failed and could not be restarted because http client is null");
+                    "@text/offline.long-polling-failed.http-client-null");
             return;
         }
 
         this.updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.UNKNOWN.NONE,
-                String.format("Long polling failed, will try to reconnect: %s", e.getMessage()));
+                String.format("@text/offline.long-polling-failed.trying-to-reconnect", e.getMessage()));
         scheduleInitialAccess(httpClient);
     }
 

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSHCBridgeHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSHCBridgeHandler.java
@@ -287,7 +287,7 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
     }
 
     private void handleLongPollFailure(Throwable e) {
-        logger.warn("Long polling failed, trying to restart", e);
+        logger.warn("Long polling failed, will try to reconnect", e);
         BoschHttpClient httpClient = this.httpClient;
         if (httpClient == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
@@ -295,12 +295,9 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
             return;
         }
 
-        try {
-            this.longPolling.start(httpClient);
-        } catch (LongPollingFailedException restartException) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
-                    String.format("Long polling failed and could not be restarted: %s", restartException.getMessage()));
-        }
+        this.updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.UNKNOWN.NONE,
+                String.format("Long polling failed, will try to reconnect: %s", e.getMessage()));
+        scheduleInitialAccess(httpClient);
     }
 
     /**

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/LongPolling.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/LongPolling.java
@@ -117,7 +117,8 @@ public class LongPolling {
             String subscriptionId = response.getResult();
             return subscriptionId;
         } catch (TimeoutException | ExecutionException | InterruptedException e) {
-            throw new LongPollingFailedException("Error on subscribe request", e);
+            throw new LongPollingFailedException(
+                    String.format("Error on subscribe request (Http client: %s)", httpClient.toString()), e);
         }
     }
 

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/LongPolling.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/LongPolling.java
@@ -118,7 +118,8 @@ public class LongPolling {
             return subscriptionId;
         } catch (TimeoutException | ExecutionException | InterruptedException e) {
             throw new LongPollingFailedException(
-                    String.format("Error on subscribe request (Http client: %s)", httpClient.toString()), e);
+                    String.format("Error on subscribe (Http client: %s): %s", httpClient.toString(), e.getMessage()),
+                    e);
         }
     }
 

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/LongPolling.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/LongPolling.java
@@ -185,6 +185,7 @@ public class LongPolling {
             return;
         }
 
+        // Check if response was failure or success
         Throwable failure = result != null ? result.getFailure() : null;
         if (failure != null) {
             if (failure instanceof ExecutionException) {
@@ -208,24 +209,24 @@ public class LongPolling {
             if (longPollResult != null && longPollResult.result != null) {
                 this.handleResult.accept(longPollResult);
             } else {
-                logger.warn("Long poll response contained no results: {}", content);
+                logger.debug("Long poll response contained no result: {}", content);
 
                 // Check if we got a proper result from the SHC
                 LongPollError longPollError = gson.fromJson(content, LongPollError.class);
 
                 if (longPollError != null && longPollError.error != null) {
-                    logger.warn("Got long poll error: {} (code: {})", longPollError.error.message,
+                    logger.debug("Got long poll error: {} (code: {})", longPollError.error.message,
                             longPollError.error.code);
 
                     if (longPollError.error.code == LongPollError.SUBSCRIPTION_INVALID) {
-                        logger.warn("Subscription {} became invalid, subscribing again", subscriptionId);
+                        logger.debug("Subscription {} became invalid, subscribing again", subscriptionId);
                         this.resubscribe(httpClient);
                         return;
                     }
                 }
             }
 
-            // Execute next run.
+            // Execute next run
             this.longPoll(httpClient, nextSubscriptionId);
         }
     }

--- a/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/i18n/boschshc.properties
+++ b/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/i18n/boschshc.properties
@@ -3,3 +3,5 @@
 offline.conf-error-pairing = Press pairing button on the Bosch Smart Home Controller.
 offline.not-reachable = Smart Home Controller is not reachable.
 offline.conf-error-ssl = The SSL connection to the Bosch Smart Home Controller is not possible.
+offline.long-polling-failed.http-client-null = Long polling failed and could not be restarted because http client is null
+offline.long-polling-failed.trying-to-reconnect = Long polling failed, will try to reconnect: %s


### PR DESCRIPTION
This fixes #62 and #74 by restarting the bridge/long polling after the long polling failed (either because the subscription expired or the controller restarted due to an update, manual restart,...).