### PR TITLE
#77 changed title of binding to Bosch Smart Home

### DIFF
--- a/bundles/org.openhab.binding.boschshc/DEVELOPERS.md
+++ b/bundles/org.openhab.binding.boschshc/DEVELOPERS.md
@@ -2,7 +2,7 @@
 
 ## Build
 
-To only build the Bosch SHC binding code execute
+To only build the Bosch Smart Home binding code execute
 
     mvn -pl :org.openhab.binding.boschshc install
 
@@ -15,28 +15,32 @@ For the first time the jar is loaded automatically as a bundle.
 
 It should also be reloaded automatically when the jar changed.
 
-To reload the bundle manually you need to execute:
+To reload the bundle manually you need to execute in the openhab console:
 
-    bundle:update "openHAB Add-ons :: Bundles :: BoschSHC Binding"
+    bundle:update "openHAB Add-ons :: Bundles :: Bosch Smart Home Binding"
    
 or get the ID and update the bundle using the ID:
 
     bundle:list
-    -> Get ID for "openHAB Add-ons :: Bundles :: BoschSHC Binding"
+    -> Get ID for "openHAB Add-ons :: Bundles :: Bosch Smart Home Binding"
     bundle:update <ID>
     
 
 ## Debugging
 
-To get debug output and traces of the Bosch SHC binding code
+To get debug output and traces of the Bosch Smart Home binding code
 add the following lines into ``userdata/etc/log4j2.xml`` Loggers XML section. 
 
     <!-- Bosch SHC for debugging -->
 	<Logger level="TRACE" name="org.openhab.binding.boschshc"/>
 
+or use the openhab console to change the log level
+
+    log:set TRACE org.openhab.binding.boschshc
+
 ## Pairing and  Certificates
 
-We need secured and paired connection from the openHAB binding instance to the Bosch SHC.  
+We need secured and paired connection from the openHAB binding instance to the Bosch Smart Home Controller (SHC).  
 
 Read more about the pairing process in [register a new client to the bosch smart home controller](https://github.com/BoschSmartHome/bosch-shc-api-docs/tree/master/postman#register-a-new-client-to-the-bosch-smart-home-controller)
 

--- a/bundles/org.openhab.binding.boschshc/README.md
+++ b/bundles/org.openhab.binding.boschshc/README.md
@@ -1,8 +1,8 @@
-# BoschSHC Binding
+# Bosch Smart Home Binding
 
 Binding for the Bosch Smart Home Controller.
 
-- [BoschSHC Binding](#boschshc-binding)
+- [Bosch Smart Home Binding](#bosch-smart-home-binding)
   - [Supported Things](#supported-things)
     - [Bosch In-Wall switches & Bosch Smart Plugs](#bosch-in-wall-switches--bosch-smart-plugs)
     - [Bosch TwinGuard smoke detector](#bosch-twinguard-smoke-detector)
@@ -13,7 +13,7 @@ Binding for the Bosch Smart Home Controller.
     - [Bosch Climate Control](#bosch-climate-control)
   - [Limitations](#limitations)
   - [Discovery](#discovery)
-  - [Binding Configuration](#binding-configuration)
+  - [Bridge Configuration](#bridge-configuration)
   - [Getting the device IDs](#getting-the-device-ids)
   - [Thing Configuration](#thing-configuration)
   - [Item Configuration](#item-configuration)
@@ -102,8 +102,8 @@ You need to provide the IP address and the system password of your Bosch Smart H
 The IP address of the controller is visible in the Bosch Smart Home Mobile App (More -> System -> Smart Home Controller) or in your network router UI.
 The system password is set by you during your initial registration steps in the _Bosch Smart Home App_.
 
-A keystore file with a self signed certificate is created automatically.
-This certificate is used for pairing between the Bridge and the Bosch SHC.
+A keystore file with a self-signed certificate is created automatically.
+This certificate is used for pairing between the Bridge and the Bosch Smart Home Controller.
 
 *Press and hold the Bosch Smart Home Controller Bridge button until the LED starts blinking after you save your settings for pairing*.
 

--- a/bundles/org.openhab.binding.boschshc/pom.xml
+++ b/bundles/org.openhab.binding.boschshc/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>org.openhab.binding.boschshc</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: BoschSHC Binding</name>
+  <name>openHAB Add-ons :: Bundles :: Bosch Smart Home Binding</name>
 
   <dependencies>
     <dependency>

--- a/bundles/org.openhab.binding.boschshc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.boschshc/src/main/feature/feature.xml
@@ -2,7 +2,7 @@
 <features name="org.openhab.binding.boschshc-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
-	<feature name="openhab-binding-boschshc" description="BoschSHC Binding" version="${project.version}">
+	<feature name="openhab-binding-boschshc" description="Bosch Smart Home Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.boschshc/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClient.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClient.java
@@ -130,8 +130,8 @@ public class BoschHttpClient extends HttpClient {
      * @throws InterruptedException in case of an interrupt
      */
     public boolean doPairing() throws InterruptedException {
-        logger.trace("Starting pairing openHAB Client with Bosch SmartHomeController!");
-        logger.trace("Please press the Bosch SHC button until LED starts blinking");
+        logger.trace("Starting pairing openHAB Client with Bosch Smart Home Controller!");
+        logger.trace("Please press the Bosch Smart Home Controller button until LED starts blinking");
 
         ContentResponse contentResponse;
         try {
@@ -169,7 +169,7 @@ public class BoschHttpClient extends HttpClient {
             // javax.net.ssl.SSLHandshakeException: General SSLEngine problem
             // => usually the pairing failed, because hardware button was not pressed.
             logger.trace("Pairing failed - Details: {}", e.getMessage());
-            logger.warn("Pairing failed. Was the Bosch SHC button pressed?");
+            logger.warn("Pairing failed. Was the Bosch Smart Home Controller button pressed?");
             return false;
         }
     }

--- a/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,7 +7,7 @@
 	<!-- Bosch Bridge -->
 	<bridge-type id="shc">
 		<label>Smart Home Controller</label>
-		<description>The Bosch SHC Bridge representing the Bosch Smart Home Controller.</description>
+		<description>The Bosch Smart Home Bridge representing the Bosch Smart Home Controller.</description>
 
 		<config-description-ref uri="thing-type:boschshc:bridge"/>
 	</bridge-type>


### PR DESCRIPTION
Replaced the SHC occurrences with "Smart Home", to avoid technical names.
