### PR TITLE
Feature/#75 access check

### DIFF
--- a/bundles/org.openhab.binding.boschshc/README.md
+++ b/bundles/org.openhab.binding.boschshc/README.md
@@ -1,6 +1,6 @@
 # Bosch Smart Home Binding
 
-Binding for the Bosch Smart Home Controller.
+Binding for the Bosch Smart Home.
 
 - [Bosch Smart Home Binding](#bosch-smart-home-binding)
   - [Supported Things](#supported-things)

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSHCBridgeHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSHCBridgeHandler.java
@@ -43,6 +43,7 @@ import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.BaseBridgeHandler;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.types.Command;
+import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,6 +84,9 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
 
     @Override
     public void initialize() {
+        logger.debug("Initialize {} Version {}", FrameworkUtil.getBundle(getClass()).getSymbolicName(),
+                FrameworkUtil.getBundle(getClass()).getVersion());
+
         // Read configuration
         BoschSHCBridgeConfiguration config = getConfigAs(BoschSHCBridgeConfiguration.class);
 
@@ -168,7 +172,7 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
      * and starts the first log poll.
      */
     private void initialAccess(BoschHttpClient httpClient) {
-        logger.debug("Initializing Bosch SHC Bridge: {} - HTTP client is: {} - version: 2020-04-05", this, httpClient);
+        logger.debug("Initializing Bosch SHC Bridge: {} - HTTP client is: {}", this, httpClient);
 
         try {
             // check access and pair if necessary

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSHCBridgeHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSHCBridgeHandler.java
@@ -27,6 +27,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.openhab.binding.boschshc.internal.devices.BoschSHCHandler;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.*;
@@ -90,20 +91,24 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
         // Read configuration
         BoschSHCBridgeConfiguration config = getConfigAs(BoschSHCBridgeConfiguration.class);
 
-        if (config.ipAddress.isEmpty()) {
-            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No IP address set");
+        String ipAddress = config.ipAddress.trim();
+        if (ipAddress.isEmpty()) {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/offline.conf-error-empty-ip");
             return;
         }
 
-        if (config.password.isEmpty()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No system password set");
+        String password = config.password.trim();
+        if (password.isEmpty()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/offline.conf-error-empty-password");
             return;
         }
 
         SslContextFactory factory;
         try {
             // prepare SSL key and certificates
-            factory = new BoschSslUtil(config.ipAddress).getSslContextFactory();
+            factory = new BoschSslUtil(ipAddress).getSslContextFactory();
         } catch (PairingFailedException e) {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
                     "@text/offline.conf-error-ssl");
@@ -111,7 +116,7 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
         }
 
         // Instantiate HttpClient with the SslContextFactory
-        BoschHttpClient httpClient = this.httpClient = new BoschHttpClient(config.ipAddress, config.password, factory);
+        BoschHttpClient httpClient = this.httpClient = new BoschHttpClient(ipAddress, password, factory);
 
         // Start http client
         try {
@@ -122,6 +127,9 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
             return;
         }
 
+        // general checks are OK, therefore set the status to unknown and wait for initial access
+        this.updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.UNKNOWN.NONE);
+
         // Initialize bridge in the background.
         // Start initial access the first time
         scheduleInitialAccess(httpClient);
@@ -130,6 +138,7 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
     @Override
     public void dispose() {
         // Cancel scheduled pairing.
+        @Nullable
         ScheduledFuture<?> scheduledPairing = this.scheduledPairing;
         if (scheduledPairing != null) {
             scheduledPairing.cancel(true);
@@ -139,6 +148,7 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
         // Stop long polling.
         this.longPolling.stop();
 
+        @Nullable
         BoschHttpClient httpClient = this.httpClient;
         if (httpClient != null) {
             try {
@@ -175,9 +185,20 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
         logger.debug("Initializing Bosch SHC Bridge: {} - HTTP client is: {}", this, httpClient);
 
         try {
-            // check access and pair if necessary
-            if (!httpClient.isAccessPossible()) {
+            // check if SCH is offline
+            if (!httpClient.isOnline()) {
                 // update status already if access is not possible
+                this.updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.UNKNOWN.NONE,
+                        "@text/offline.conf-error-offline");
+                // restart later initial access
+                scheduleInitialAccess(httpClient);
+                return;
+            }
+
+            // SHC is online
+            // check if SHC access is not possible and pairing necessary
+            if (!httpClient.isAccessPossible()) {
+                // update status description to show pairing test
                 this.updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.UNKNOWN.NONE,
                         "@text/offline.conf-error-pairing");
                 if (!httpClient.doPairing()) {
@@ -186,52 +207,61 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
                 }
                 // restart initial access - needed also in case of successful pairing to check access again
                 scheduleInitialAccess(httpClient);
-            } else {
-                // print rooms and devices if things are reachable
-                boolean thingReachable = true;
-                thingReachable &= this.getRooms();
-                thingReachable &= this.getDevices();
-
-                if (thingReachable) {
-                    this.updateStatus(ThingStatus.ONLINE);
-
-                    // Start long polling
-                    try {
-                        this.longPolling.start(httpClient);
-                    } catch (LongPollingFailedException e) {
-                        this.handleLongPollFailure(e);
-                    }
-                } else {
-                    this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
-                            "@text/offline.not-reachable");
-                    // restart initial access
-                    scheduleInitialAccess(httpClient);
-                }
+                return;
             }
+
+            // SHC is online and access is possible
+            // print rooms and devices
+            boolean thingReachable = true;
+            thingReachable &= this.getRooms();
+            thingReachable &= this.getDevices();
+            if (!thingReachable) {
+                this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
+                        "@text/offline.not-reachable");
+                // restart initial access
+                scheduleInitialAccess(httpClient);
+                return;
+            }
+
+            // start long polling loop
+            this.updateStatus(ThingStatus.ONLINE);
+            try {
+                this.longPolling.start(httpClient);
+            } catch (LongPollingFailedException e) {
+                this.handleLongPollFailure(e);
+            }
+
         } catch (InterruptedException e) {
-            this.updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.UNKNOWN.NONE,
-                    String.format("Pairing was interrupted: %s", e.getMessage()));
+            this.updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.UNKNOWN.NONE, "@text/offline.interrupted");
         }
     }
 
     /**
      * Get a list of connected devices from the Smart-Home Controller
      * 
-     * @throws InterruptedException
+     * @throws InterruptedException in case bridge is stopped
      */
     private boolean getDevices() throws InterruptedException {
+        @Nullable
         BoschHttpClient httpClient = this.httpClient;
         if (httpClient == null) {
             return false;
         }
 
         try {
-            logger.debug("Sending http request to Bosch to request clients: {}", httpClient);
+            logger.debug("Sending http request to Bosch to request devices: {}", httpClient);
             String url = httpClient.getBoschSmartHomeUrl("devices");
             ContentResponse contentResponse = httpClient.createRequest(url, GET).send();
 
+            // check HTTP status code
+            if (!HttpStatus.getCode(contentResponse.getStatus()).isSuccess()) {
+                logger.debug("Request devices failed with status code: {}", contentResponse.getStatus());
+                return false;
+            }
+
             String content = contentResponse.getContentAsString();
-            logger.debug("Response complete: {} - return code: {}", content, contentResponse.getStatus());
+            logger.debug("Request devices completed with success: {} - status code: {}", content,
+                    contentResponse.getStatus());
 
             Type collectionType = new TypeToken<ArrayList<Device>>() {
             }.getType();
@@ -249,13 +279,21 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
                 }
             }
         } catch (TimeoutException | ExecutionException e) {
-            logger.debug("HTTP request failed with exception {}", e.getMessage());
+            logger.warn("Request devices failed because of {}!", e.getMessage());
             return false;
         }
 
         return true;
     }
 
+    /**
+     * Bridge callback handler for the results of long polls.
+     *
+     * It will check the result and
+     * forward the received to the bosch thing handlers.
+     *
+     * @param result Results from Long Polling
+     */
     private void handleLongPollResult(LongPollResult result) {
         for (DeviceStatusUpdate update : result.result) {
             if (update != null && update.state != null) {
@@ -266,9 +304,11 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
                 Bridge bridge = this.getThing();
                 for (Thing childThing : bridge.getThings()) {
                     // All children of this should implement BoschSHCHandler
+                    @Nullable
                     ThingHandler baseHandler = childThing.getHandler();
                     if (baseHandler != null && baseHandler instanceof BoschSHCHandler) {
                         BoschSHCHandler handler = (BoschSHCHandler) baseHandler;
+                        @Nullable
                         String deviceId = handler.getBoschID();
 
                         handled = true;
@@ -290,8 +330,16 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
         }
     }
 
+    /**
+     * Bridge callback handler for the failures during long polls.
+     *
+     * It will update the bridge status and try to access the SHC again.
+     *
+     * @param e error during long polling
+     */
     private void handleLongPollFailure(Throwable e) {
         logger.warn("Long polling failed, will try to reconnect", e);
+        @Nullable
         BoschHttpClient httpClient = this.httpClient;
         if (httpClient == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
@@ -300,16 +348,17 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
         }
 
         this.updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.UNKNOWN.NONE,
-                String.format("@text/offline.long-polling-failed.trying-to-reconnect", e.getMessage()));
+                "@text/offline.long-polling-failed.trying-to-reconnect");
         scheduleInitialAccess(httpClient);
     }
 
     /**
      * Get a list of rooms from the Smart-Home controller
      * 
-     * @throws InterruptedException
+     * @throws InterruptedException in case bridge is stopped
      */
     private boolean getRooms() throws InterruptedException {
+        @Nullable
         BoschHttpClient httpClient = this.httpClient;
         if (httpClient != null) {
             try {
@@ -317,8 +366,15 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
                 String url = httpClient.getBoschSmartHomeUrl("rooms");
                 ContentResponse contentResponse = httpClient.createRequest(url, GET).send();
 
+                // check HTTP status code
+                if (!HttpStatus.getCode(contentResponse.getStatus()).isSuccess()) {
+                    logger.debug("Request rooms failed with status code: {}", contentResponse.getStatus());
+                    return false;
+                }
+
                 String content = contentResponse.getContentAsString();
-                logger.debug("Response complete: {} - return code: {}", content, contentResponse.getStatus());
+                logger.debug("Request rooms completed with success: {} - status code: {}", content,
+                        contentResponse.getStatus());
 
                 Type collectionType = new TypeToken<ArrayList<Room>>() {
                 }.getType();
@@ -333,7 +389,7 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
 
                 return true;
             } catch (TimeoutException | ExecutionException e) {
-                logger.warn("HTTP request failed: {}", e.getMessage());
+                logger.warn("Request rooms failed because of {}!", e.getMessage());
                 return false;
             }
         } else {
@@ -354,6 +410,7 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
      */
     public <T extends BoschSHCServiceState> @Nullable T getState(String deviceId, String stateName, Class<T> stateClass)
             throws InterruptedException, TimeoutException, ExecutionException, BoschSHCException {
+        @Nullable
         BoschHttpClient httpClient = this.httpClient;
         if (httpClient == null) {
             logger.warn("HttpClient not initialized");
@@ -406,6 +463,7 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
      */
     public <T extends BoschSHCServiceState> @Nullable Response putState(String deviceId, String serviceName, T state)
             throws InterruptedException, TimeoutException, ExecutionException {
+        @Nullable
         BoschHttpClient httpClient = this.httpClient;
         if (httpClient == null) {
             logger.warn("HttpClient not initialized");
@@ -417,7 +475,6 @@ public class BoschSHCBridgeHandler extends BaseBridgeHandler {
         Request request = httpClient.createRequest(url, PUT, state);
 
         // Send request
-        Response response = request.send();
-        return response;
+        return request.send();
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/binding/binding.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
 	<name>Bosch Smart Home Binding</name>
-	<description>This is the binding for Bosch Smart Home Controller.</description>
+	<description>This is the binding for Bosch Smart Home.</description>
 	<author>Stefan Kästle</author>
 
 </binding:binding>

--- a/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/i18n/boschshc.properties
+++ b/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/i18n/boschshc.properties
@@ -1,7 +1,12 @@
 
+
 # Thing status offline descriptions
+offline.conf-error-empty-ip = No network address set.
+offline.conf-error-empty-password = No system password set.
+offline.conf-error-offline = The Bosch Smart Home Controller is offline or network address is wrong.
 offline.conf-error-pairing = Press pairing button on the Bosch Smart Home Controller.
-offline.not-reachable = Smart Home Controller is not reachable.
+offline.not-reachable = The Bosch Smart Home Controller is not reachable.
 offline.conf-error-ssl = The SSL connection to the Bosch Smart Home Controller is not possible.
-offline.long-polling-failed.http-client-null = Long polling failed and could not be restarted because http client is null
-offline.long-polling-failed.trying-to-reconnect = Long polling failed, will try to reconnect: %s
+offline.long-polling-failed.http-client-null = Long polling failed and could not be restarted because http client is null.
+offline.long-polling-failed.trying-to-reconnect = Long polling failed, will try to reconnect.
+offline.interrupted = Conneting to Bosch Smart Home Controller was interrupted.

--- a/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/i18n/boschshc_de.properties
+++ b/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/i18n/boschshc_de.properties
@@ -1,7 +1,7 @@
-# binding
-binding.boschshc.name = Bosch Smart Home Controller Binding
-binding.boschshc.description = Dieses Binding integriert das Bosch Smart Home System. Durch diese können die Bosch Smart Home Geräte verwendet werden.
 
+# binding.xml strings
+binding.boschshc.name = Bosch Smart Home Binding
+binding.boschshc.description = Dieses Binding integriert das Bosch Smart Home System. Durch diese können die Bosch Smart Home Geräte verwendet werden.
 
 # Thing status offline descriptions
 offline.conf-error-pairing = Bitte betätigen Sie den Taster am Bosch Smart Home Controller zum automatischen Verbinden.

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClientTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClientTest.java
@@ -49,6 +49,11 @@ class BoschHttpClientTest {
     }
 
     @Test
+    void getPublicInformationUrl() {
+        assertEquals("https://127.0.0.1:8446/smarthome/public/information", httpClient.getPublicInformationUrl());
+    }
+
+    @Test
     void getPairingUrl() {
         assertEquals("https://127.0.0.1:8443/smarthome/clients", httpClient.getPairingUrl());
     }
@@ -73,6 +78,11 @@ class BoschHttpClientTest {
     @Test
     void isAccessPossible() throws InterruptedException {
         assertFalse(httpClient.isAccessPossible());
+    }
+
+    @Test
+    void isOnline() throws InterruptedException {
+        assertFalse(httpClient.isOnline());
     }
 
     @Test


### PR DESCRIPTION
Improved Access check to fix #75

- added isOnline check and isAccessPossible now failed in case HTTPStatus is an error
- same HTTPStatus check done to all blocking send() request calls
- using i18n strings for all bridge updateStatus calls
- skipped the 'controller' and use only 'Bosch Smart Home' in descriptions
- added more @Nullable annotations 

Tested the new strings, the case that SHC address is wrong (offline) and the pairing.
A test of the initial access during SHC boot-up is pending.