### PR TITLE
Bridge and Device discovery

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/BoschSHCBindingConstants.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/BoschSHCBindingConstants.java
@@ -26,7 +26,7 @@ import org.openhab.core.thing.ThingTypeUID;
 @NonNullByDefault
 public class BoschSHCBindingConstants {
 
-    private static final String BINDING_ID = "boschshc";
+    public static final String BINDING_ID = "boschshc";
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_SHC = new ThingTypeUID(BINDING_ID, "shc");

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClient.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClient.java
@@ -290,11 +290,11 @@ public class BoschHttpClient extends HttpClient {
             if (errorResponseHandler != null) {
                 throw errorResponseHandler.apply(statusCode, textContent);
             } else {
-                throw new ExecutionException(String.format("Request failed with status code %s", statusCode), null);
+                throw new ExecutionException(String.format("Send request failed with status code %s", statusCode), null);
             }
         }
 
-        logger.debug("Received response: {} - status: {}", textContent, statusCode);
+        logger.debug("Send request completed with success: {} - status code: {}", textContent, statusCode);
 
         try {
             @Nullable

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClient.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClient.java
@@ -56,12 +56,10 @@ public class BoschHttpClient extends HttpClient {
     private final Logger logger = LoggerFactory.getLogger(BoschHttpClient.class);
 
     private final String ipAddress;
-    private final String systemPassword;
 
-    public BoschHttpClient(String ipAddress, String systemPassword, SslContextFactory sslContextFactory) {
+    public BoschHttpClient(String ipAddress, SslContextFactory sslContextFactory) {
         super(sslContextFactory);
         this.ipAddress = ipAddress;
-        this.systemPassword = systemPassword;
     }
 
     /**
@@ -181,7 +179,7 @@ public class BoschHttpClient extends HttpClient {
      * @return true if pairing was successful, otherwise false
      * @throws InterruptedException in case of an interrupt
      */
-    public boolean doPairing() throws InterruptedException {
+    public boolean doPairing(String systemPassword) throws InterruptedException {
         logger.trace("Starting pairing openHAB Client with Bosch Smart Home Controller!");
         logger.trace("Please press the Bosch Smart Home Controller button until LED starts blinking");
 
@@ -201,7 +199,7 @@ public class BoschHttpClient extends HttpClient {
 
             String url = this.getPairingUrl();
             Request request = this.createRequest(url, HttpMethod.POST, items).header("Systempassword",
-                    Base64.getEncoder().encodeToString(this.systemPassword.getBytes(StandardCharsets.UTF_8)));
+                    Base64.getEncoder().encodeToString(systemPassword.getBytes(StandardCharsets.UTF_8)));
 
             contentResponse = request.send();
 
@@ -290,7 +288,8 @@ public class BoschHttpClient extends HttpClient {
             if (errorResponseHandler != null) {
                 throw errorResponseHandler.apply(statusCode, textContent);
             } else {
-                throw new ExecutionException(String.format("Send request failed with status code %s", statusCode), null);
+                throw new ExecutionException(String.format("Send request failed with status code %s", statusCode),
+                        null);
             }
         }
 

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSslUtil.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSslUtil.java
@@ -43,7 +43,7 @@ import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.openhab.binding.boschshc.internal.exceptions.PairingFailedException;
+import org.openhab.binding.boschshc.internal.exceptions.KeystoreException;
 import org.openhab.core.OpenHAB;
 import org.openhab.core.id.InstanceUUID;
 import org.slf4j.Logger;
@@ -104,7 +104,7 @@ public class BoschSslUtil {
         return Paths.get(OpenHAB.getUserDataFolder(), "etc", getBoschShcServerId() + ".jks").toString();
     }
 
-    public SslContextFactory getSslContextFactory() throws PairingFailedException {
+    public SslContextFactory getSslContextFactory() throws KeystoreException {
         // Instantiate and configure the SslContextFactory
         SslContextFactory sslContextFactory = new SslContextFactory.Client.Client(true); // Accept all certificates
 
@@ -125,7 +125,7 @@ public class BoschSslUtil {
         return sslContextFactory;
     }
 
-    public KeyStore getKeyStoreAndCreateIfNecessary() throws PairingFailedException {
+    public KeyStore getKeyStoreAndCreateIfNecessary() throws KeystoreException {
         try {
             File file = new File(keystorePath);
             if (!file.exists()) {
@@ -143,8 +143,8 @@ public class BoschSslUtil {
             }
         } catch (OperatorCreationException | GeneralSecurityException | IOException e) {
             logger.debug("Exception during keystore creation {}", e.getMessage());
-            throw new PairingFailedException("Can not create or load keystore file: " + keystorePath
-                    + ". Check path, write access and JKS content.", e);
+            throw new KeystoreException("Can not create or load keystore file: " + keystorePath
+                    + ". Check path, write access and JavaKeyStore content.", e);
         }
     }
 

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BridgeHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BridgeHandler.java
@@ -16,6 +16,8 @@ import static org.eclipse.jetty.http.HttpMethod.*;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -33,9 +35,10 @@ import org.openhab.binding.boschshc.internal.devices.bridge.dto.Device;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.DeviceStatusUpdate;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.LongPollResult;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.Room;
+import org.openhab.binding.boschshc.internal.discovery.ThingDiscoveryService;
 import org.openhab.binding.boschshc.internal.exceptions.BoschSHCException;
+import org.openhab.binding.boschshc.internal.exceptions.KeystoreException;
 import org.openhab.binding.boschshc.internal.exceptions.LongPollingFailedException;
-import org.openhab.binding.boschshc.internal.exceptions.PairingFailedException;
 import org.openhab.binding.boschshc.internal.services.dto.BoschSHCServiceState;
 import org.openhab.binding.boschshc.internal.services.dto.JsonRestExceptionResponse;
 import org.openhab.core.thing.Bridge;
@@ -45,6 +48,7 @@ import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.BaseBridgeHandler;
 import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
 import org.openhab.core.types.Command;
 import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
@@ -75,14 +79,30 @@ public class BridgeHandler extends BaseBridgeHandler {
      */
     private final LongPolling longPolling;
 
+    /**
+     * HTTP Client for Bosch SHC rest calls and long polling.
+     */
     private @Nullable BoschHttpClient httpClient;
 
+    /**
+     * Future result to handle successful or failed pairing between bridge and SHC.
+     */
     private @Nullable ScheduledFuture<?> scheduledPairing;
+
+    /**
+     * Bosch SHC system password
+     */
+    private String password;
 
     public BridgeHandler(Bridge bridge) {
         super(bridge);
-
+        this.password = "";
         this.longPolling = new LongPolling(this.scheduler, this::handleLongPollResult, this::handleLongPollFailure);
+    }
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Collections.singleton(ThingDiscoveryService.class);
     }
 
     @Override
@@ -100,8 +120,8 @@ public class BridgeHandler extends BaseBridgeHandler {
             return;
         }
 
-        String password = config.password.trim();
-        if (password.isEmpty()) {
+        this.password = config.password.trim();
+        if (this.password.isEmpty()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/offline.conf-error-empty-password");
             return;
@@ -111,14 +131,14 @@ public class BridgeHandler extends BaseBridgeHandler {
         try {
             // prepare SSL key and certificates
             factory = new BoschSslUtil(ipAddress).getSslContextFactory();
-        } catch (PairingFailedException e) {
+        } catch (KeystoreException e) {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
                     "@text/offline.conf-error-ssl");
             return;
         }
 
         // Instantiate HttpClient with the SslContextFactory
-        BoschHttpClient httpClient = this.httpClient = new BoschHttpClient(ipAddress, password, factory);
+        BoschHttpClient httpClient = this.httpClient = new BoschHttpClient(ipAddress, factory);
 
         // Start http client
         try {
@@ -203,7 +223,7 @@ public class BridgeHandler extends BaseBridgeHandler {
                 // update status description to show pairing test
                 this.updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.UNKNOWN.NONE,
                         "@text/offline.conf-error-pairing");
-                if (!httpClient.doPairing()) {
+                if (!httpClient.doPairing(this.password)) {
                     this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
                             "@text/offline.conf-error-pairing");
                 }
@@ -216,7 +236,7 @@ public class BridgeHandler extends BaseBridgeHandler {
             // print rooms and devices
             boolean thingReachable = true;
             thingReachable &= this.getRooms();
-            thingReachable &= this.getDevices();
+            thingReachable &= (this.getDevices() != null);
             if (!thingReachable) {
                 this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
                         "@text/offline.not-reachable");
@@ -232,7 +252,6 @@ public class BridgeHandler extends BaseBridgeHandler {
             } catch (LongPollingFailedException e) {
                 this.handleLongPollFailure(e);
             }
-
         } catch (InterruptedException e) {
             this.updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.UNKNOWN.NONE, "@text/offline.interrupted");
             Thread.currentThread().interrupt();
@@ -244,11 +263,11 @@ public class BridgeHandler extends BaseBridgeHandler {
      *
      * @throws InterruptedException in case bridge is stopped
      */
-    private boolean getDevices() throws InterruptedException {
+    public @Nullable ArrayList<Device> getDevices() throws InterruptedException {
         @Nullable
         BoschHttpClient httpClient = this.httpClient;
         if (httpClient == null) {
-            return false;
+            return null;
         }
 
         try {
@@ -259,7 +278,7 @@ public class BridgeHandler extends BaseBridgeHandler {
             // check HTTP status code
             if (!HttpStatus.getCode(contentResponse.getStatus()).isSuccess()) {
                 logger.debug("Request devices failed with status code: {}", contentResponse.getStatus());
-                return false;
+                return null;
             }
 
             String content = contentResponse.getContentAsString();
@@ -270,23 +289,23 @@ public class BridgeHandler extends BaseBridgeHandler {
             }.getType();
             ArrayList<Device> devices = gson.fromJson(content, collectionType);
 
-            if (devices != null) {
-                for (Device d : devices) {
-                    // Write found devices into openhab.log until we have implemented auto discovery
-                    logger.info("Found device: name={} id={}", d.name, d.id);
-                    if (d.deviceSerivceIDs != null) {
-                        for (String s : d.deviceSerivceIDs) {
-                            logger.info(".... service: {}", s);
-                        }
-                    }
-                }
-            }
+            // if (devices != null) {
+            // for (Device d : devices) {
+            // // Write found devices into openhab.log until we have implemented auto discovery
+            // logger.info("Found device: name={} id={}", d.name, d.id);
+            // if (d.deviceSerivceIDs != null) {
+            // for (String s : d.deviceSerivceIDs) {
+            // logger.info(".... service: {}", s);
+            // }
+            // }
+            // }
+            // }
+
+            return devices;
         } catch (TimeoutException | ExecutionException e) {
             logger.warn("Request devices failed because of {}!", e.getMessage());
-            return false;
+            return null;
         }
-
-        return true;
     }
 
     /**
@@ -386,7 +405,7 @@ public class BridgeHandler extends BaseBridgeHandler {
 
                 if (rooms != null) {
                     for (Room r : rooms) {
-                        logger.info("Found room: {}", r.name);
+                        logger.info("Found room: {} (ID={})", r.name, r.id);
                     }
                 }
 

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/dto/PublicInformation.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/dto/PublicInformation.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschshc.internal.devices.bridge.dto;
+
+
+/**
+ * Public Information of the controller.
+ *
+ * Currently the ipAddress is used for discovery. More fields can be added on demand.
+ *
+ * Json example:
+ * {
+ * "apiVersions":["1.2","2.1"],
+ * ...
+ * "shcIpAddress":"192.168.1.2",
+ * ...
+ * }
+ *
+ * @author Gerd Zanker - Initial contribution
+ */
+public class PublicInformation {
+
+    public String shcIpAddress;
+}

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/dto/PublicInformation.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/dto/PublicInformation.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.boschshc.internal.devices.bridge.dto;
 
-
 /**
  * Public Information of the controller.
  *

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/discovery/BridgeDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/discovery/BridgeDiscoveryParticipant.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschshc.internal.discovery;
+
+import java.net.InetAddress;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import javax.jmdns.ServiceInfo;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.openhab.binding.boschshc.internal.devices.BoschSHCBindingConstants;
+import org.openhab.binding.boschshc.internal.devices.bridge.dto.PublicInformation;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.mdns.MDNSDiscoveryParticipant;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+
+/**
+ * The {@link BridgeDiscoveryParticipant} is responsible discovering the
+ * Bosch Smart Home Controller as a Bridge with the mDNS services.
+ *
+ * @author Gerd Zanker - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "discovery.boschsmarthomebridge")
+public class BridgeDiscoveryParticipant implements MDNSDiscoveryParticipant {
+
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(BoschSHCBindingConstants.THING_TYPE_SHC);
+
+    private final Gson gson = new Gson();
+    private final Logger logger = LoggerFactory.getLogger(BridgeDiscoveryParticipant.class);
+    private final HttpClient httpClient;
+
+    public BridgeDiscoveryParticipant() {
+        // create http client upfront to later get public information from SHC
+        SslContextFactory sslContextFactory = new SslContextFactory.Client.Client(true); // Accept all certificates
+        sslContextFactory.setTrustAll(true);
+        sslContextFactory.setValidateCerts(false);
+        sslContextFactory.setValidatePeerCerts(false);
+        sslContextFactory.setEndpointIdentificationAlgorithm(null);
+        httpClient = new HttpClient(sslContextFactory);
+    }
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
+        return SUPPORTED_THING_TYPES_UIDS;
+    }
+
+    @Override
+    public String getServiceType() {
+        return "_http._tcp.local.";
+    }
+
+    @Override
+    public @Nullable DiscoveryResult createResult(ServiceInfo serviceInfo) {
+        logger.debug("Bridge Discovery started for {}", serviceInfo);
+
+        @Nullable
+        final ThingUID uid = getThingUID(serviceInfo);
+        if (uid == null) {
+            return null;
+        }
+
+        String ipAddress = uid.getId().replace('-', '.');
+        logger.info("Discovered Bosch Smart Home Controller at {}", ipAddress);
+
+        return DiscoveryResultBuilder.create(uid).withProperty("ipAddress", ipAddress)
+                .withLabel("Bosch Smart Home Controller").withTTL(60 * 60 * 24).build();
+    }
+
+    @Override
+    public @Nullable ThingUID getThingUID(ServiceInfo serviceInfo) {
+        @Nullable
+        String ipAddress = getBridgeAddress(serviceInfo);
+        if (ipAddress != null) {
+            return new ThingUID(BoschSHCBindingConstants.THING_TYPE_SHC, ipAddress.replace('.', '-'));
+        }
+        return null;
+    }
+
+    private @Nullable String getBridgeAddress(ServiceInfo serviceInfo) {
+        logger.trace("Discovering serviceInfo {}", serviceInfo);
+
+        for (InetAddress address : serviceInfo.getInetAddresses()) {
+            logger.trace("Discovering InetAddress {}", address);
+            @Nullable
+            String bridgeAddress = getBridgeAddress(address.getHostAddress());
+            if (bridgeAddress != null) {
+                return bridgeAddress;
+            }
+        }
+
+        return null;
+    }
+
+    private @Nullable String getBridgeAddress(String ipAddress) {
+
+        String url = String.format("https://%s:8446/smarthome/public/information", ipAddress);
+        logger.trace("Discovering ipAddress {}", url);
+        try {
+            httpClient.start();
+            ContentResponse contentResponse = httpClient.newRequest(url).method(HttpMethod.GET).send();
+            // check HTTP status code
+            if (!HttpStatus.getCode(contentResponse.getStatus()).isSuccess()) {
+                logger.debug("Discovering failed with status code: {}", contentResponse.getStatus());
+                return null;
+            }
+
+            String content = contentResponse.getContentAsString();
+            logger.debug("Discovered SHC - public info {}", content);
+            @Nullable
+            PublicInformation versionInfo = gson.fromJson(content, PublicInformation.class);
+            if (versionInfo != null) {
+                return versionInfo.shcIpAddress;
+            }
+            return null;
+
+        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            logger.trace("Discovering failed with exception", e);
+            return null;
+        } catch (Exception e) {
+            logger.trace("Discovering failed in http client start", e);
+            return null;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/discovery/ThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/discovery/ThingDiscoveryService.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschshc.internal.discovery;
+
+import java.util.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.boschshc.internal.devices.BoschSHCBindingConstants;
+import org.openhab.binding.boschshc.internal.devices.bridge.BridgeHandler;
+import org.openhab.binding.boschshc.internal.devices.bridge.dto.Device;
+import org.openhab.core.config.discovery.AbstractDiscoveryService;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.DiscoveryService;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link ThingDiscoveryService} is responsible discover Bosch Smart Home things.
+ *
+ * @author Gerd Zanker - Initial contribution
+ */
+@NonNullByDefault
+public class ThingDiscoveryService extends AbstractDiscoveryService implements DiscoveryService, ThingHandlerService {
+    private static final int SEARCH_TIME = 10;
+
+    private final Logger logger = LoggerFactory.getLogger(ThingDiscoveryService.class);
+    private @Nullable BridgeHandler bridgeHandler;
+
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Set.of(
+            BoschSHCBindingConstants.THING_TYPE_INWALL_SWITCH, BoschSHCBindingConstants.THING_TYPE_TWINGUARD,
+            BoschSHCBindingConstants.THING_TYPE_WINDOW_CONTACT, BoschSHCBindingConstants.THING_TYPE_MOTION_DETECTOR,
+            BoschSHCBindingConstants.THING_TYPE_SHUTTER_CONTROL, BoschSHCBindingConstants.THING_TYPE_THERMOSTAT,
+            BoschSHCBindingConstants.THING_TYPE_CLIMATE_CONTROL, BoschSHCBindingConstants.THING_TYPE_WALL_THERMOSTAT);
+
+    // @formatter:off
+    private static final Map<String, String> DEVICEMODEL_TO_THING_MAP = Map.ofEntries(
+            new AbstractMap.SimpleEntry<>("BBL", BoschSHCBindingConstants.THING_TYPE_SHUTTER_CONTROL.getId()),
+            new AbstractMap.SimpleEntry<>("TWINGUARD", BoschSHCBindingConstants.THING_TYPE_TWINGUARD.getId()),
+            new AbstractMap.SimpleEntry<>("PSM", BoschSHCBindingConstants.THING_TYPE_INWALL_SWITCH.getId()),
+            new AbstractMap.SimpleEntry<>("PLUG_COMPACT", BoschSHCBindingConstants.THING_TYPE_INWALL_SWITCH.getId()),
+            new AbstractMap.SimpleEntry<>("ROOM_CLIMATE_CONTROL", BoschSHCBindingConstants.THING_TYPE_CLIMATE_CONTROL.getId()),
+            new AbstractMap.SimpleEntry<>("BWTH", BoschSHCBindingConstants.THING_TYPE_WALL_THERMOSTAT.getId())
+
+// FIXME: map all supported openhab Binding Things to the unknown Bosch SHC names
+//            new AbstractMap.SimpleEntry<>("???", BoschSHCBindingConstants.THING_TYPE_WINDOW_CONTACT.getId())
+//            new AbstractMap.SimpleEntry<>("???", BoschSHCBindingConstants.THING_TYPE_MOTION_DETECTOR.getId())
+//            new AbstractMap.SimpleEntry<>("???", BoschSHCBindingConstants.THING_TYPE_THERMOSTAT.getId())
+
+
+// FUTURE IMPLEMENTATION: map all Bosch SHC Names to currently not implemented Openhab Binding Things
+
+//            new AbstractMap.SimpleEntry<>("CAMERA_EYES", ?), // Eyes 360 outdoor camera
+//            new AbstractMap.SimpleEntry<>("SD", ?), // smoke detector
+
+//            new AbstractMap.SimpleEntry<>("VENTILATION_SERVICE", ?),
+//            new AbstractMap.SimpleEntry<>("SMOKE_DETECTION_SYSTEM", ?),
+//            new AbstractMap.SimpleEntry<>("PRESENCE_SIMULATION_SERVICE", ?),
+
+//            new AbstractMap.SimpleEntry<>("HUE_BRIDGE", ?)
+//            new AbstractMap.SimpleEntry<>("HUE_BRIDGE_MANAGER", ?)
+//            new AbstractMap.SimpleEntry<>("HUE_LIGHT", ?)
+//            new AbstractMap.SimpleEntry<>("HUE_LIGHT_ROOM_CONTROL", ?)
+
+            );
+    // @formatter:on
+
+    public ThingDiscoveryService() {
+        super(SUPPORTED_THING_TYPES, SEARCH_TIME);
+    }
+
+    @Override
+    public void activate() {
+        logger.trace("activate");
+        // TODO: Preparation for ongoing discovery while bridge is online
+        // final BridgeHandler handler = this.bridgeHandler;
+        // if (handler != null) {
+        // handler.registerDiscoveryListener(this);
+        // }
+    }
+
+    @Override
+    public void deactivate() {
+        logger.trace("DEactivate");
+        // TODO: Preparation for ongoing discovery while bridge is online
+        // final BridgeHandler handler = this.bridgeHandler;
+        // if (handler != null) {
+        // removeOlderResults(new Date().getTime(), handler.getThing().getUID());
+        // handler.unregisterDiscoveryListener();
+        // } else {
+        // logger.debug("DEactivate called, but can't removeOlderResults because no UID available!!!");
+        // }
+    }
+
+    @Override
+    protected void startScan() {
+        // use shcBridgeHandler to getDevices()
+        try {
+            final BridgeHandler bridgeHandler;
+            if (this.bridgeHandler != null) {
+                bridgeHandler = this.bridgeHandler;
+                @Nullable
+                ArrayList<Device> devices = bridgeHandler.getDevices();
+                if (devices != null) {
+                    for (Device device : devices) {
+                        addDevice(device);
+                    }
+                }
+            }
+        } catch (InterruptedException e) {
+            logger.trace("scan was interrupted");
+        }
+    }
+
+    private void addDevice(Device device) {
+        logger.debug("Discovering device {}", device.name);
+        logger.trace("   Details for device {}:\n" + "- id: {}\n" + "- manufacturer: {}\n" + "- roomId: {}\n"
+                + "- deviceModel: {}\n" + "- serial: {}\n" + "- name: {}\n" + "- status: {}\n" + "- childDeviceIds: {}",
+                device.name, device.id, device.manufacturer, device.roomId, device.deviceModel, device.serial,
+                device.name, device.status, device.childDeviceIds);
+
+        final BridgeHandler bridgeHandler;
+        if (this.bridgeHandler != null) {
+            bridgeHandler = this.bridgeHandler;
+            ThingUID bridgeUID = bridgeHandler.getThing().getUID();
+            @Nullable
+            ThingTypeUID thingTypeUID = getThingTypeUID(device);
+            if (thingTypeUID == null)
+                return;
+
+            ThingUID thingUID = getThingUID(device, bridgeUID, thingTypeUID);
+
+            DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+                    .withProperty("id", device.id).withBridge(bridgeUID)
+                    // TODO add openhab "Location" based on the SHC "rooms",
+                    // look necessary via the SHC id for rooms like "hz_2"
+                    // .withRepresentationProperty(UNIQUE_ID)
+                    .withLabel(device.name).build();
+
+            logger.debug("Discovered device '{}' with thingUID={}, thingTypeUID={}, id={}", device.name, thingUID,
+                    thingTypeUID, device.id);
+
+            thingDiscovered(discoveryResult);
+        }
+    }
+
+    private ThingUID getThingUID(Device device, ThingUID bridgeUid, ThingTypeUID thingTypeUID) {
+        logger.trace("got getThingUID {} for device {}", device.id, device);
+        return new ThingUID(thingTypeUID, bridgeUid, device.id.replace(':', '_'));
+    }
+
+    private @Nullable ThingTypeUID getThingTypeUID(Device device) {
+        String thingTypeId = DEVICEMODEL_TO_THING_MAP.get(device.deviceModel);
+        if (thingTypeId != null) {
+            logger.trace("got thingTypeID {} for deviceModel {}", thingTypeId, device.deviceModel);
+            return new ThingTypeUID(BoschSHCBindingConstants.BINDING_ID, thingTypeId);
+        }
+        logger.info(
+                "The Bosch Smart Home binding doesn't support this deviceModel {}. Please request support for it in github.",
+                device.deviceModel);
+        return null;
+    }
+
+    @Override
+    public void setThingHandler(@Nullable ThingHandler handler) {
+        if (handler instanceof BridgeHandler) {
+            logger.trace("Set bridge handler {}", handler);
+            bridgeHandler = (BridgeHandler) handler;
+        }
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return bridgeHandler;
+    }
+}

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/exceptions/KeystoreException.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/exceptions/KeystoreException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschshc.internal.exceptions;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown if the keystore for SSL keys & certificate cant be created or accessed.
+ * 
+ * @author Gerd Zanker - Initial contribution
+ */
+@SuppressWarnings("serial")
+@NonNullByDefault
+public class KeystoreException extends BoschSHCException {
+    public KeystoreException() {
+    }
+
+    public KeystoreException(String message) {
+        super(message);
+    }
+
+    public KeystoreException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/i18n/boschshc.properties
+++ b/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/i18n/boschshc.properties
@@ -9,7 +9,7 @@ offline.not-reachable = The Bosch Smart Home Controller is not reachable.
 offline.conf-error-ssl = The SSL connection to the Bosch Smart Home Controller is not possible.
 offline.long-polling-failed.http-client-null = Long polling failed and could not be restarted because http client is null.
 offline.long-polling-failed.trying-to-reconnect = Long polling failed, will try to reconnect.
-offline.interrupted = Conneting to Bosch Smart Home Controller was interrupted.
+offline.interrupted = Connecting to Bosch Smart Home Controller was interrupted.
 
 offline.conf-error.empty-device-id = No device ID set.
 

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClientTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClientTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.SubscribeResult;
-import org.openhab.binding.boschshc.internal.exceptions.PairingFailedException;
+import org.openhab.binding.boschshc.internal.exceptions.KeystoreException;
 
 /**
  * Tests cases for {@link BoschHttpClient}.
@@ -42,9 +42,9 @@ class BoschHttpClientTest {
     }
 
     @BeforeEach
-    void beforeEach() throws PairingFailedException {
+    void beforeEach() throws KeystoreException {
         SslContextFactory sslFactory = new BoschSslUtil("127.0.0.1").getSslContextFactory();
-        httpClient = new BoschHttpClient("127.0.0.1", "dummy", sslFactory);
+        httpClient = new BoschHttpClient("127.0.0.1", sslFactory);
         assertNotNull(httpClient);
     }
 
@@ -87,7 +87,7 @@ class BoschHttpClientTest {
 
     @Test
     void doPairing() throws InterruptedException {
-        assertFalse(httpClient.doPairing());
+        assertFalse(httpClient.doPairing("unknownPassword"));
     }
 
     @Test

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSslUtilTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschSslUtilTest.java
@@ -22,7 +22,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.openhab.binding.boschshc.internal.exceptions.PairingFailedException;
+import org.openhab.binding.boschshc.internal.exceptions.KeystoreException;
 
 /**
  * Tests cases for {@link BoschSslUtil}.
@@ -72,7 +72,7 @@ class BoschSslUtilTest {
      * Test if the keyStore can be created if it doesn't exist.
      */
     @Test
-    void keyStoreAndFactory() throws PairingFailedException {
+    void keyStoreAndFactory() throws KeystoreException {
         BoschSslUtil sslUtil1 = new BoschSslUtil("127.0.0.1");
 
         // remote old, existing jks


### PR DESCRIPTION
Bridge and Device discovery for Bosch Smart Home

Bridge IP address is discovered via mDNS and query of public information
Device discovery requires a paired bride and must be started manually via "Scan" button.
Currently not all supported devices are discovered, but ShutterControl and TwinGuard shall work.

A lot of debugs and traces are in to simplify problem analysis.

Unit tests are pending, but needed to keep functionality stable for future.