### PR TITLE
Doing correct state type check

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BridgeHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BridgeHandler.java
@@ -318,7 +318,8 @@ public class BridgeHandler extends BaseBridgeHandler {
                         logger.debug("Registered device: {} - looking for {}", deviceId, update.deviceId);
 
                         if (deviceId != null && update.deviceId.equals(deviceId)) {
-                            logger.debug("Found child: {} - calling processUpdate with {}", handler, update.state);
+                            logger.debug("Found child: {} - calling processUpdate (id: {}) with {}", handler, update.id,
+                                    update.state);
                             handler.processUpdate(update.id, update.state);
                         }
                     } else {
@@ -473,7 +474,7 @@ public class BridgeHandler extends BaseBridgeHandler {
         }
 
         @Nullable
-        T state = gson.fromJson(content, stateClass);
+        T state = BoschSHCServiceState.fromJson(content, stateClass);
         if (state == null) {
             throw new BoschSHCException(String.format("Received invalid, expected type %s", stateClass.getName()));
         }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/dto/BoschSHCServiceState.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/services/dto/BoschSHCServiceState.java
@@ -13,6 +13,8 @@
 package org.openhab.binding.boschshc.internal.services.dto;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -24,15 +26,18 @@ import com.google.gson.annotations.SerializedName;
  * @author Christian Oeing - Initial contribution
  */
 public class BoschSHCServiceState {
+
     /**
      * gson instance to convert a class to json string and back.
      */
     private static final Gson gson = new Gson();
 
+    private static final Logger logger = LoggerFactory.getLogger(BoschSHCServiceState.class);
+
     /**
-     * State type. Initialized when first instance is created.
+     * State type. Initialized when instance is created.
      */
-    private static @Nullable String stateType = null;
+    private @Nullable String stateType = null;
 
     @SerializedName("@type")
     private final String type;
@@ -51,7 +56,23 @@ public class BoschSHCServiceState {
 
     protected boolean isValid() {
         String expectedType = stateType;
-        return expectedType != null && expectedType.equals(this.type);
+        if (expectedType == null || !expectedType.equals(this.type)) {
+            logger.debug(String.format("Expected state type %s for state class %s, received %s", expectedType,
+                    this.getClass().getName(), this.type));
+            return false;
+        }
+
+        return true;
+    }
+
+    public static <TState extends BoschSHCServiceState> @Nullable TState fromJson(String json,
+            Class<TState> stateClass) {
+        var state = gson.fromJson(json, stateClass);
+        if (state == null || !state.isValid()) {
+            return null;
+        }
+
+        return state;
     }
 
     public static <TState extends BoschSHCServiceState> @Nullable TState fromJson(JsonElement json,

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/services/dto/BoschSHCServiceStateTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/services/dto/BoschSHCServiceStateTest.java
@@ -33,6 +33,17 @@ class TestState extends BoschSHCServiceState {
 }
 
 /**
+ * Test class
+ *
+ * @author Christian Oeing - Initial contribution
+ */
+class TestState2 extends BoschSHCServiceState {
+    public TestState2() {
+        super("testState2");
+    }
+}
+
+/**
  * Unit tests for BoschSHCServiceStateTest
  *
  * @author Christian Oeing - Initial contribution
@@ -53,5 +64,16 @@ public class BoschSHCServiceStateTest {
         var state = BoschSHCServiceState.fromJson(gson.fromJson("{\"@type\":\"testState\"}", JsonObject.class),
                 TestState.class);
         assertNotEquals(null, state);
+    }
+
+    /**
+     * This checks for a bug we had where the expected type stayed the same for different state classes
+     */
+    @Test
+    public void fromJson_stateObjectForValidJsonAfterOtherState() {
+        BoschSHCServiceState.fromJson(gson.fromJson("{\"@type\":\"testState\"}", JsonObject.class), TestState.class);
+        var state2 = BoschSHCServiceState.fromJson(gson.fromJson("{\"@type\":\"testState2\"}", JsonObject.class),
+                TestState2.class);
+        assertNotEquals(null, state2);
     }
 }


### PR DESCRIPTION
Closes #101 

Store expected state type inside a member instead of a static variable.

The static variable was stored in the base class, so it was only initialized once even for different state types.
