### PR TITLE
Better error for missing bridge

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/BoschSHCHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/BoschSHCHandler.java
@@ -197,11 +197,13 @@ public abstract class BoschSHCHandler extends BaseThingHandler {
     protected BridgeHandler getBridgeHandler() throws BoschSHCException {
         Bridge bridge = this.getBridge();
         if (bridge == null) {
-            throw new BoschSHCException(String.format("No valid bridge set for %s", this.getThing()));
+            throw new BoschSHCException(String.format("No valid bridge set for %s (%s)", this.getThing().getLabel(),
+                    this.getThing().getUID().getAsString()));
         }
         BridgeHandler bridgeHandler = (BridgeHandler) bridge.getHandler();
         if (bridgeHandler == null) {
-            throw new BoschSHCException(String.format("Bridge of %s has no valid bridge handler", this.getThing()));
+            throw new BoschSHCException(String.format("Bridge of %s (%s) has no valid bridge handler",
+                    this.getThing().getLabel(), this.getThing().getUID().getAsString()));
         }
         return bridgeHandler;
     }


### PR DESCRIPTION
Part of solution for #63 

I am using the label (human-readable identifier) and UID (unique identifier) in the error message now to make sure the user knows which thing has an invalid/missing bridge.